### PR TITLE
Add weekly balance forecasting and storage scaffolding

### DIFF
--- a/app/components/ImporterTool.tsx
+++ b/app/components/ImporterTool.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import type { EndingBalanceCell, WeeklyBalanceCell } from '../../lib/forecast';
+
+interface ImportPayload {
+  monthly: EndingBalanceCell[];
+  weekly: WeeklyBalanceCell[];
+}
+
+async function persistMonthlyBalances(rows: EndingBalanceCell[]): Promise<void> {
+  await fetch('/api/pf_monthly_balances', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rows }),
+  });
+}
+
+async function persistWeeklyBalances(rows: WeeklyBalanceCell[]): Promise<void> {
+  await fetch('/api/pf_weekly_balances', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rows }),
+  });
+}
+
+function parseImportPayload(text: string): ImportPayload {
+  const parsed = JSON.parse(text);
+  if (!Array.isArray(parsed.monthly) || !Array.isArray(parsed.weekly)) {
+    throw new Error('Import payload must include monthly and weekly arrays.');
+  }
+  return {
+    monthly: parsed.monthly as EndingBalanceCell[],
+    weekly: parsed.weekly as WeeklyBalanceCell[],
+  };
+}
+
+const ImporterTool: React.FC = () => {
+  const [status, setStatus] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  const handleImport = useCallback(async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const text = formData.get('payload');
+
+    if (typeof text !== 'string' || text.trim().length === 0) {
+      setError('Paste the JSON payload before importing.');
+      setStatus('');
+      return;
+    }
+
+    try {
+      setError('');
+      setStatus('Importing…');
+      const payload = parseImportPayload(text);
+      await persistMonthlyBalances(payload.monthly);
+      await persistWeeklyBalances(payload.weekly);
+      setStatus('Import complete. Monthly and weekly balances saved.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error during import.';
+      setError(message);
+      setStatus('');
+    }
+  }, []);
+
+  return (
+    <section className="importer">
+      <h2 className="text-xl font-semibold mb-2">Bulk Balance Import</h2>
+      <p className="text-sm text-gray-600 mb-4">
+        Paste the exported JSON containing <code>monthly</code> and <code>weekly</code> arrays to persist ending balances
+        along with interim flags.
+      </p>
+      <form onSubmit={handleImport} className="grid gap-3">
+        <textarea
+          name="payload"
+          rows={12}
+          className="border rounded p-2 font-mono text-sm"
+          placeholder='{"monthly": [...], "weekly": [...]}'
+        />
+        <button type="submit" className="bg-blue-600 text-white rounded px-4 py-2">
+          Import balances
+        </button>
+      </form>
+      {status && <p className="text-sm text-green-700 mt-2" role="status">{status}</p>}
+      {error && <p className="text-sm text-red-600 mt-2" role="alert">{error}</p>}
+    </section>
+  );
+};
+
+export default ImporterTool;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import {
+  buildForecast,
+  type BuildForecastParams,
+  type WeeklyBalanceCell,
+  type EndingBalanceCell,
+} from '../lib/forecast';
+
+const sampleParams: BuildForecastParams = {
+  months: ['2025-01', '2025-02'],
+  priorEndingBalances: {
+    operating: 1250,
+    profit: 300,
+  },
+  occurrences: [
+    { accountSlug: 'operating', amount: 450, timestamp: '2025-01-03T10:00:00Z' },
+    { accountSlug: 'operating', amount: -180, timestamp: '2025-01-07T18:30:00Z' },
+    { accountSlug: 'operating', amount: -220, timestamp: '2025-01-20T15:45:00Z' },
+    { accountSlug: 'operating', amount: 375, timestamp: '2025-02-04T09:05:00Z' },
+    { accountSlug: 'operating', amount: -120, timestamp: '2025-02-12T12:00:00Z' },
+    { accountSlug: 'operating', amount: -315, timestamp: '2025-02-21T13:15:00Z' },
+    { accountSlug: 'profit', amount: 75, timestamp: '2025-01-10T11:00:00Z' },
+    { accountSlug: 'profit', amount: -50, timestamp: '2025-01-25T08:00:00Z' },
+    { accountSlug: 'profit', amount: 80, timestamp: '2025-02-08T16:00:00Z' },
+  ],
+  checkpoints: [
+    {
+      id: 'cp-operating-jan',
+      accountSlug: 'operating',
+      balance: 1480,
+      timestamp: '2025-01-17T14:00:00Z',
+    },
+    {
+      id: 'cp-profit-feb',
+      accountSlug: 'profit',
+      balance: 430,
+      timestamp: '2025-02-18T13:30:00Z',
+    },
+  ],
+};
+
+const forecast = buildForecast(sampleParams);
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+  });
+}
+
+function renderMonthlyRow(month: string, account: string, cell: EndingBalanceCell): JSX.Element {
+  return (
+    <tr key={`${month}-${account}`}>
+      <td className="font-mono text-xs text-gray-500">{month}</td>
+      <td className="font-semibold capitalize">{account}</td>
+      <td>{formatCurrency(cell.beginningBalance)}</td>
+      <td>{formatCurrency(cell.netAfterAnchor)}</td>
+      <td>{formatCurrency(cell.balance)}</td>
+      <td>{cell.anchor.source}</td>
+      <td>{cell.anchor.isInterim ? 'Yes' : 'No'}</td>
+    </tr>
+  );
+}
+
+function renderWeeklyRows(month: string, weekKey: string, cells: Record<string, WeeklyBalanceCell>): JSX.Element[] {
+  return forecast.accounts.map((account) => {
+    const cell = cells[account];
+    if (!cell) return null;
+    return (
+      <tr key={`${month}-${weekKey}-${account}`}>
+        <td className="font-mono text-xs text-gray-500">{month}</td>
+        <td className="font-mono text-xs">{weekKey}</td>
+        <td className="capitalize font-medium">{account}</td>
+        <td>{formatCurrency(cell.beginningBalance)}</td>
+        <td>{formatCurrency(cell.netAfterAnchor)}</td>
+        <td>{formatCurrency(cell.balance)}</td>
+        <td>{cell.anchor.source}</td>
+        <td>{cell.anchor.isInterim ? 'Yes' : 'No'}</td>
+      </tr>
+    );
+  }).filter(Boolean) as JSX.Element[];
+}
+
+export default function Page(): JSX.Element {
+  return (
+    <main className="p-8 space-y-12">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Forecast Dashboard</h1>
+        <p className="text-gray-600 max-w-2xl">
+          Monthly and weekly balances now track interim checkpoints. Beginning balances roll forward from the prior period
+          unless a checkpoint overrides the anchor mid-period.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Monthly Balances</h2>
+        <div className="overflow-x-auto border rounded-lg">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Month</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Account</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Beginning</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Net Activity</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Ending</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Anchor Source</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Interim?</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {forecast.months.flatMap((month) =>
+                forecast.accounts.map((account) => {
+                  const cell = forecast.endingBalances[month]?.[account];
+                  return cell ? renderMonthlyRow(month, account, cell) : null;
+                }),
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Weekly Balances</h2>
+        <div className="overflow-x-auto border rounded-lg">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Month</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Week Ending</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Account</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Beginning</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Net Activity</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Ending</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Anchor Source</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600">Interim?</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {forecast.months.flatMap((month) => {
+                const weeks = Object.entries(forecast.weeklyBalances[month] || {}).sort((a, b) =>
+                  a[0].localeCompare(b[0]),
+                );
+                return weeks.flatMap(([weekKey, cells]) => renderWeeklyRows(month, weekKey, cells));
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface MonthlyFormState {
+  ym: string;
+  accountSlug: string;
+  isInterim: boolean;
+}
+
+interface WeeklyFormState {
+  ym: string;
+  weekEnd: string;
+  accountSlug: string;
+  isInterim: boolean;
+}
+
+async function updateMonthlyInterim(payload: MonthlyFormState): Promise<void> {
+  await fetch('/api/pf_monthly_balances/interim', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+async function updateWeeklyInterim(payload: WeeklyFormState): Promise<void> {
+  await fetch('/api/pf_weekly_balances/interim', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+const SettingsPage: React.FC = () => {
+  const [monthlyForm, setMonthlyForm] = useState<MonthlyFormState>({
+    ym: '2025-01',
+    accountSlug: 'operating',
+    isInterim: false,
+  });
+  const [weeklyForm, setWeeklyForm] = useState<WeeklyFormState>({
+    ym: '2025-01',
+    weekEnd: '2025-01-12',
+    accountSlug: 'operating',
+    isInterim: false,
+  });
+  const [status, setStatus] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  const handleMonthlyChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value, type, checked } = event.target;
+    setMonthlyForm((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+  };
+
+  const handleWeeklyChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value, type, checked } = event.target;
+    setWeeklyForm((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      setError('');
+      setStatus('Saving…');
+      await updateMonthlyInterim(monthlyForm);
+      await updateWeeklyInterim(weeklyForm);
+      setStatus('Settings updated. Interim flags saved for monthly and weekly balances.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to save settings.';
+      setError(message);
+      setStatus('');
+    }
+  };
+
+  return (
+    <main className="p-8 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Balance Settings</h1>
+        <p className="text-gray-600 max-w-xl">
+          Toggle whether a period&apos;s beginning balance originates from a mid-period checkpoint. Weekly settings mirror the
+          existing monthly controls to keep forecasts aligned with the data stored in Supabase.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <section className="space-y-3">
+          <h2 className="text-lg font-medium">Monthly Interim Flag</h2>
+          <div className="grid gap-3 md:grid-cols-3">
+            <label className="grid gap-1 text-sm">
+              <span>Month (YYYY-MM)</span>
+              <input
+                type="text"
+                name="ym"
+                value={monthlyForm.ym}
+                onChange={handleMonthlyChange}
+                className="border rounded px-2 py-1"
+                placeholder="2025-01"
+              />
+            </label>
+            <label className="grid gap-1 text-sm">
+              <span>Account Slug</span>
+              <input
+                type="text"
+                name="accountSlug"
+                value={monthlyForm.accountSlug}
+                onChange={handleMonthlyChange}
+                className="border rounded px-2 py-1"
+                placeholder="operating"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                name="isInterim"
+                checked={monthlyForm.isInterim}
+                onChange={handleMonthlyChange}
+              />
+              <span>Beginning balance comes from a checkpoint</span>
+            </label>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-lg font-medium">Weekly Interim Flag</h2>
+          <div className="grid gap-3 md:grid-cols-4">
+            <label className="grid gap-1 text-sm">
+              <span>Month (YYYY-MM)</span>
+              <input
+                type="text"
+                name="ym"
+                value={weeklyForm.ym}
+                onChange={handleWeeklyChange}
+                className="border rounded px-2 py-1"
+                placeholder="2025-01"
+              />
+            </label>
+            <label className="grid gap-1 text-sm">
+              <span>Week Ending (ISO date)</span>
+              <input
+                type="date"
+                name="weekEnd"
+                value={weeklyForm.weekEnd}
+                onChange={handleWeeklyChange}
+                className="border rounded px-2 py-1"
+              />
+            </label>
+            <label className="grid gap-1 text-sm">
+              <span>Account Slug</span>
+              <input
+                type="text"
+                name="accountSlug"
+                value={weeklyForm.accountSlug}
+                onChange={handleWeeklyChange}
+                className="border rounded px-2 py-1"
+                placeholder="operating"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                name="isInterim"
+                checked={weeklyForm.isInterim}
+                onChange={handleWeeklyChange}
+              />
+              <span>Checkpoint overrides beginning balance</span>
+            </label>
+          </div>
+        </section>
+
+        <button type="submit" className="bg-blue-600 text-white rounded px-4 py-2">
+          Save settings
+        </button>
+      </form>
+
+      {status && <p className="text-sm text-green-700" role="status">{status}</p>}
+      {error && <p className="text-sm text-red-600" role="alert">{error}</p>}
+    </main>
+  );
+};
+
+export default SettingsPage;

--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -1,0 +1,67 @@
+-- Schema excerpts relevant to profit forecasting balances.
+
+-- Existing monthly balances table gains an interim flag.
+ALTER TABLE public.pf_monthly_balances
+  ADD COLUMN IF NOT EXISTS is_interim boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.pf_monthly_balances.is_interim IS
+  'Indicates that the beginning balance for the month comes from a mid-month checkpoint.';
+
+-- Weekly balance storage mirrors the monthly snapshot table.
+CREATE TABLE IF NOT EXISTS public.pf_weekly_balances (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id uuid NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  ym char(7) NOT NULL,
+  week_end_date date NOT NULL,
+  pf_slug text NOT NULL,
+  beginning_balance numeric NOT NULL DEFAULT 0,
+  ending_balance numeric NOT NULL DEFAULT 0,
+  is_interim boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_pf_weekly_balances UNIQUE (client_id, week_end_date, pf_slug),
+  CONSTRAINT fk_pf_weekly_balances_account FOREIGN KEY (client_id, pf_slug)
+    REFERENCES public.pf_accounts(client_id, slug) ON DELETE CASCADE,
+  CONSTRAINT ck_pf_weekly_balances_ym_format CHECK (ym ~ '^[0-9]{4}-[0-9]{2}$')
+);
+
+COMMENT ON TABLE public.pf_weekly_balances IS
+  'Week-end balance snapshots for each Profit First account with beginning/ending balances and interim markers.';
+COMMENT ON COLUMN public.pf_weekly_balances.ym IS
+  'Year-month (YYYY-MM) indicating which calendar month the week belongs to.';
+COMMENT ON COLUMN public.pf_weekly_balances.week_end_date IS
+  'The ISO date that marks the end of the represented week.';
+COMMENT ON COLUMN public.pf_weekly_balances.is_interim IS
+  'True when the beginning balance was sourced from a mid-week checkpoint.';
+
+CREATE INDEX IF NOT EXISTS idx_pf_weekly_balances_client_ym
+  ON public.pf_weekly_balances (client_id, ym);
+CREATE INDEX IF NOT EXISTS idx_pf_weekly_balances_client_week
+  ON public.pf_weekly_balances (client_id, week_end_date);
+
+CREATE OR REPLACE FUNCTION public.touch_pf_weekly_balances_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_touch_pf_weekly_balances_updated_at ON public.pf_weekly_balances;
+CREATE TRIGGER trg_touch_pf_weekly_balances_updated_at
+  BEFORE UPDATE ON public.pf_weekly_balances
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_pf_weekly_balances_updated_at();
+
+CREATE OR REPLACE VIEW public.v_pf_weekly_balances AS
+SELECT
+  client_id,
+  ym,
+  week_end_date,
+  pf_slug,
+  beginning_balance,
+  ending_balance,
+  is_interim
+FROM public.pf_weekly_balances;
+
+GRANT SELECT ON public.v_pf_weekly_balances TO authenticated;

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -1,0 +1,436 @@
+export type AccountSlug = string;
+
+export interface Occurrence {
+  accountSlug: AccountSlug;
+  /**
+   * Positive values represent inflows while negative values represent outflows.
+   */
+  amount: number;
+  /**
+   * ISO-8601 timestamp that marks when the occurrence should be applied.
+   */
+  timestamp: string;
+}
+
+export interface AnchorCheckpoint {
+  id: string;
+  accountSlug: AccountSlug;
+  /**
+   * The balance that was observed at the checkpoint timestamp.
+   */
+  balance: number;
+  /**
+   * ISO-8601 timestamp for the observation.
+   */
+  timestamp: string;
+}
+
+export interface AnchorMetadata {
+  balance: number;
+  timestamp: string;
+  source: 'checkpoint' | 'rollforward' | 'initial';
+  checkpointId?: string;
+  /**
+   * True when a checkpoint within the period overrides the default beginning
+   * balance.  This allows the consumer to surface that the balance represents a
+   * mid-period reconciliation rather than the start-of-period roll forward.
+   */
+  isInterim?: boolean;
+}
+
+export interface EndingBalanceCell {
+  ym: string;
+  accountSlug: AccountSlug;
+  /** Beginning balance that was used to compute the ending value. */
+  beginningBalance: number;
+  /** Ending balance for the period. */
+  balance: number;
+  /** Net activity applied after the anchor timestamp. */
+  netAfterAnchor: number;
+  anchor: AnchorMetadata;
+}
+
+export interface WeeklyBalanceCell {
+  ym: string;
+  accountSlug: AccountSlug;
+  /** ISO date string representing the week end (Sunday). */
+  weekKey: string;
+  beginningBalance: number;
+  balance: number;
+  netAfterAnchor: number;
+  anchor: AnchorMetadata;
+}
+
+export interface ForecastResult {
+  months: string[];
+  accounts: AccountSlug[];
+  endingBalances: Record<string, Record<AccountSlug, EndingBalanceCell>>;
+  weeklyBalances: Record<string, Record<string, Record<AccountSlug, WeeklyBalanceCell>>>;
+}
+
+export interface BuildForecastParams {
+  months: string[];
+  occurrences: Occurrence[];
+  /** Prior ending balances that seed the roll-forward calculations. */
+  priorEndingBalances: Record<AccountSlug, number>;
+  checkpoints: AnchorCheckpoint[];
+}
+
+function toUtcDate(timestamp: string): Date {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid timestamp: ${timestamp}`);
+  }
+  return date;
+}
+
+function startOfMonth(ym: string): Date {
+  const [year, month] = ym.split('-').map(Number);
+  if (!year || !month) {
+    throw new Error(`Invalid month identifier: ${ym}`);
+  }
+  return new Date(Date.UTC(year, month - 1, 1));
+}
+
+function monthEndExclusive(ym: string): Date {
+  const [year, month] = ym.split('-').map(Number);
+  if (!year || !month) {
+    throw new Error(`Invalid month identifier: ${ym}`);
+  }
+  return new Date(Date.UTC(year, month, 1));
+}
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function toIsoTimestamp(date: Date): string {
+  return date.toISOString();
+}
+
+function clonePriorBalances(source: Record<AccountSlug, number>): Record<AccountSlug, number> {
+  return Object.fromEntries(Object.entries(source || {}).map(([key, value]) => [key, value]));
+}
+
+function listAccounts(
+  occurrences: Occurrence[],
+  checkpoints: AnchorCheckpoint[],
+  priorEndingBalances: Record<AccountSlug, number>,
+): AccountSlug[] {
+  const accounts = new Set<AccountSlug>();
+  occurrences.forEach((item) => accounts.add(item.accountSlug));
+  checkpoints.forEach((item) => accounts.add(item.accountSlug));
+  Object.keys(priorEndingBalances || {}).forEach((key) => accounts.add(key));
+  return Array.from(accounts).sort();
+}
+
+function sortIsoStrings<T extends { timestamp: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const diff = toUtcDate(a.timestamp).getTime() - toUtcDate(b.timestamp).getTime();
+    return diff;
+  });
+}
+
+function filterOccurrencesForWindow(
+  occurrences: Occurrence[],
+  account: AccountSlug,
+  windowStart: Date,
+  windowEnd: Date,
+): Occurrence[] {
+  const startMs = windowStart.getTime();
+  const endMs = windowEnd.getTime();
+  return occurrences.filter((occ) => {
+    if (occ.accountSlug !== account) return false;
+    const ts = toUtcDate(occ.timestamp).getTime();
+    return ts >= startMs && ts < endMs;
+  });
+}
+
+function filterCheckpointsForWindow(
+  checkpoints: AnchorCheckpoint[],
+  account: AccountSlug,
+  windowStart: Date,
+  windowEnd: Date,
+): AnchorCheckpoint[] {
+  const startMs = windowStart.getTime();
+  const endMs = windowEnd.getTime();
+  return checkpoints.filter((cp) => {
+    if (cp.accountSlug !== account) return false;
+    const ts = toUtcDate(cp.timestamp).getTime();
+    return ts >= startMs && ts < endMs;
+  });
+}
+
+export function computeEndingBalances(
+  months: string[],
+  occurrences: Occurrence[],
+  priorEndingBalances: Record<AccountSlug, number>,
+  checkpoints: AnchorCheckpoint[],
+): Record<string, Record<AccountSlug, EndingBalanceCell>> {
+  const orderedMonths = [...months].sort();
+  const accounts = listAccounts(occurrences, checkpoints, priorEndingBalances);
+  const priorBalances = clonePriorBalances(priorEndingBalances);
+
+  const monthlyResult: Record<string, Record<AccountSlug, EndingBalanceCell>> = {};
+
+  for (const ym of orderedMonths) {
+    const monthStart = startOfMonth(ym);
+    const monthEnd = monthEndExclusive(ym);
+    const monthCells: Record<AccountSlug, EndingBalanceCell> = {};
+
+    for (const account of accounts) {
+      const accountOccurrences = filterOccurrencesForWindow(occurrences, account, monthStart, monthEnd);
+      const accountCheckpoints = sortIsoStrings(
+        filterCheckpointsForWindow(checkpoints, account, monthStart, monthEnd),
+      );
+
+      const hadPriorBalance = Object.prototype.hasOwnProperty.call(priorBalances, account);
+      const priorBalance = hadPriorBalance ? priorBalances[account] : 0;
+
+      let anchor: AnchorMetadata = {
+        balance: priorBalance,
+        timestamp: toIsoTimestamp(monthStart),
+        source: hadPriorBalance ? 'rollforward' : 'initial',
+        isInterim: false,
+      };
+
+      if (accountCheckpoints.length > 0) {
+        const latestCheckpoint = accountCheckpoints[accountCheckpoints.length - 1];
+        const checkpointTimestamp = toUtcDate(latestCheckpoint.timestamp);
+        anchor = {
+          balance: latestCheckpoint.balance,
+          timestamp: latestCheckpoint.timestamp,
+          source: 'checkpoint',
+          checkpointId: latestCheckpoint.id,
+          isInterim: checkpointTimestamp.getTime() > monthStart.getTime(),
+        };
+      }
+
+      const anchorTime = toUtcDate(anchor.timestamp).getTime();
+      const netAfterAnchor = accountOccurrences
+        .filter((occ) => {
+          const occTime = toUtcDate(occ.timestamp).getTime();
+          if (occTime < anchorTime) return false;
+          if (anchor.source === 'checkpoint' && occTime === anchorTime) return false;
+          return true;
+        })
+        .reduce((sum, occ) => sum + occ.amount, 0);
+
+      const endingBalance = anchor.balance + netAfterAnchor;
+
+      priorBalances[account] = endingBalance;
+
+      monthCells[account] = {
+        ym,
+        accountSlug: account,
+        beginningBalance: anchor.balance,
+        balance: endingBalance,
+        netAfterAnchor,
+        anchor,
+      };
+    }
+
+    monthlyResult[ym] = monthCells;
+  }
+
+  return monthlyResult;
+}
+
+interface WeekWindow {
+  start: Date;
+  end: Date; // exclusive end (start of next week)
+  /** ISO date string for the week end (Sunday). */
+  weekKey: string;
+}
+
+function computeWeeksInMonth(ym: string): WeekWindow[] {
+  const result: WeekWindow[] = [];
+  const monthStart = startOfMonth(ym);
+  const monthEnd = monthEndExclusive(ym);
+
+  let cursor = new Date(monthStart.getTime());
+
+  while (cursor.getTime() < monthEnd.getTime()) {
+    const weekStart = new Date(cursor.getTime());
+    const dayOfWeek = weekStart.getUTCDay();
+    const weekEnd = new Date(weekStart.getTime());
+    weekEnd.setUTCDate(weekEnd.getUTCDate() + (dayOfWeek === 0 ? 0 : 7 - dayOfWeek));
+    if (weekEnd.getTime() <= weekStart.getTime()) {
+      weekEnd.setUTCDate(weekEnd.getUTCDate() + 7);
+    }
+    const exclusiveEnd = new Date(Math.min(weekEnd.getTime() + 24 * 60 * 60 * 1000, monthEnd.getTime()));
+    const weekKeyDate = new Date(exclusiveEnd.getTime() - 24 * 60 * 60 * 1000);
+    const weekKey = toIsoDate(weekKeyDate);
+    result.push({ start: weekStart, end: exclusiveEnd, weekKey });
+
+    cursor = exclusiveEnd;
+  }
+
+  return result;
+}
+
+export function computeWeeklyBalances(
+  months: string[],
+  occurrences: Occurrence[],
+  priorEndingBalances: Record<AccountSlug, number>,
+  checkpoints: AnchorCheckpoint[],
+): Record<string, Record<string, Record<AccountSlug, WeeklyBalanceCell>>> {
+  const orderedMonths = [...months].sort();
+  const accounts = listAccounts(occurrences, checkpoints, priorEndingBalances);
+  const priorBalances = clonePriorBalances(priorEndingBalances);
+
+  const weeklyResult: Record<string, Record<string, Record<AccountSlug, WeeklyBalanceCell>>> = {};
+
+  for (const ym of orderedMonths) {
+    const weeks = computeWeeksInMonth(ym);
+    const monthWeeks: Record<string, Record<AccountSlug, WeeklyBalanceCell>> = {};
+
+    for (const week of weeks) {
+      const weekCells: Record<AccountSlug, WeeklyBalanceCell> = {};
+
+      for (const account of accounts) {
+        const accountOccurrences = filterOccurrencesForWindow(
+          occurrences,
+          account,
+          week.start,
+          week.end,
+        );
+        const accountCheckpoints = sortIsoStrings(
+          filterCheckpointsForWindow(checkpoints, account, week.start, week.end),
+        );
+
+        const hadPriorBalance = Object.prototype.hasOwnProperty.call(priorBalances, account);
+        const priorBalance = hadPriorBalance ? priorBalances[account] : 0;
+
+        let anchor: AnchorMetadata = {
+          balance: priorBalance,
+          timestamp: toIsoTimestamp(week.start),
+          source: hadPriorBalance ? 'rollforward' : 'initial',
+          isInterim: false,
+        };
+
+        if (accountCheckpoints.length > 0) {
+          const latestCheckpoint = accountCheckpoints[accountCheckpoints.length - 1];
+          const checkpointTimestamp = toUtcDate(latestCheckpoint.timestamp);
+          anchor = {
+            balance: latestCheckpoint.balance,
+            timestamp: latestCheckpoint.timestamp,
+            source: 'checkpoint',
+            checkpointId: latestCheckpoint.id,
+            isInterim: checkpointTimestamp.getTime() > week.start.getTime(),
+          };
+        }
+
+        const anchorTime = toUtcDate(anchor.timestamp).getTime();
+        const netAfterAnchor = accountOccurrences
+          .filter((occ) => {
+            const occTime = toUtcDate(occ.timestamp).getTime();
+            if (occTime < anchorTime) return false;
+            if (anchor.source === 'checkpoint' && occTime === anchorTime) return false;
+            return true;
+          })
+          .reduce((sum, occ) => sum + occ.amount, 0);
+
+        const endingBalance = anchor.balance + netAfterAnchor;
+        priorBalances[account] = endingBalance;
+
+        weekCells[account] = {
+          ym,
+          accountSlug: account,
+          weekKey: week.weekKey,
+          beginningBalance: anchor.balance,
+          balance: endingBalance,
+          netAfterAnchor,
+          anchor,
+        };
+      }
+
+      monthWeeks[week.weekKey] = weekCells;
+    }
+
+    weeklyResult[ym] = monthWeeks;
+  }
+
+  return weeklyResult;
+}
+
+function almostEqual(a: number, b: number, tolerance = 0.01): boolean {
+  return Math.abs(a - b) <= tolerance;
+}
+
+export function assertBalanceRollForward(
+  endingBalances: Record<string, Record<AccountSlug, EndingBalanceCell>>,
+): void {
+  const orderedMonths = Object.keys(endingBalances).sort();
+  const lastEnding: Record<AccountSlug, number> = {};
+
+  for (const ym of orderedMonths) {
+    const monthCells = endingBalances[ym];
+    for (const [account, cell] of Object.entries(monthCells)) {
+      const expectedBeginning = lastEnding[account];
+      if (expectedBeginning !== undefined && !almostEqual(cell.beginningBalance, expectedBeginning)) {
+        throw new Error(
+          `Monthly roll-forward violation for ${account} in ${ym}: expected beginning ${expectedBeginning}, got ${cell.beginningBalance}`,
+        );
+      }
+      lastEnding[account] = cell.balance;
+    }
+  }
+}
+
+export function assertWeeklyBalanceRollForward(
+  weeklyBalances: Record<string, Record<string, Record<AccountSlug, WeeklyBalanceCell>>>,
+  endingBalances: Record<string, Record<AccountSlug, EndingBalanceCell>>,
+): void {
+  const orderedMonths = Object.keys(weeklyBalances).sort();
+  const lastEnding: Record<AccountSlug, number> = {};
+
+  for (const ym of orderedMonths) {
+    const weekMap = weeklyBalances[ym];
+    const weekKeys = Object.keys(weekMap).sort();
+
+    for (const weekKey of weekKeys) {
+      const weekCells = weekMap[weekKey];
+      for (const [account, cell] of Object.entries(weekCells)) {
+        const expectedBeginning = lastEnding[account];
+        if (expectedBeginning !== undefined && !almostEqual(cell.beginningBalance, expectedBeginning)) {
+          throw new Error(
+            `Weekly roll-forward violation for ${account} in week ${weekKey}: expected beginning ${expectedBeginning}, got ${cell.beginningBalance}`,
+          );
+        }
+        lastEnding[account] = cell.balance;
+      }
+    }
+
+    const monthEndingCells = endingBalances[ym] || {};
+    for (const [account, monthCell] of Object.entries(monthEndingCells)) {
+      const lastWeekKey = weekKeys[weekKeys.length - 1];
+      const lastWeekCell = lastWeekKey ? weekMap[lastWeekKey]?.[account] : undefined;
+      if (lastWeekCell && !almostEqual(lastWeekCell.balance, monthCell.balance)) {
+        throw new Error(
+          `Weekly/monthly mismatch for ${account} in ${ym}: weekly ending ${lastWeekCell.balance}, monthly ending ${monthCell.balance}`,
+        );
+      }
+    }
+  }
+}
+
+export function buildForecast(params: BuildForecastParams): ForecastResult {
+  const { months, occurrences, priorEndingBalances, checkpoints } = params;
+  const orderedMonths = [...months].sort();
+  const accounts = listAccounts(occurrences, checkpoints, priorEndingBalances);
+
+  const endingBalances = computeEndingBalances(orderedMonths, occurrences, priorEndingBalances, checkpoints);
+  assertBalanceRollForward(endingBalances);
+
+  const weeklyBalances = computeWeeklyBalances(orderedMonths, occurrences, priorEndingBalances, checkpoints);
+  assertWeeklyBalanceRollForward(weeklyBalances, endingBalances);
+
+  return {
+    months: orderedMonths,
+    accounts,
+    endingBalances,
+    weeklyBalances,
+  };
+}
+

--- a/supabase/migrations/20250118000000_add_weekly_balances.sql
+++ b/supabase/migrations/20250118000000_add_weekly_balances.sql
@@ -1,0 +1,69 @@
+-- Migration: add weekly balance tracking and interim flags.
+
+-- Step 1: ensure the monthly balances table records interim checkpoints.
+ALTER TABLE public.pf_monthly_balances
+  ADD COLUMN IF NOT EXISTS is_interim boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.pf_monthly_balances.is_interim IS
+  'Indicates that the beginning balance for the month comes from a mid-month checkpoint.';
+
+-- Step 2: create weekly balances table mirroring monthly snapshots.
+CREATE TABLE public.pf_weekly_balances (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id uuid NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  ym char(7) NOT NULL,
+  week_end_date date NOT NULL,
+  pf_slug text NOT NULL,
+  beginning_balance numeric NOT NULL DEFAULT 0,
+  ending_balance numeric NOT NULL DEFAULT 0,
+  is_interim boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_pf_weekly_balances UNIQUE (client_id, week_end_date, pf_slug),
+  CONSTRAINT fk_pf_weekly_balances_account FOREIGN KEY (client_id, pf_slug)
+    REFERENCES public.pf_accounts(client_id, slug) ON DELETE CASCADE,
+  CONSTRAINT ck_pf_weekly_balances_ym_format CHECK (ym ~ '^[0-9]{4}-[0-9]{2}$')
+);
+
+COMMENT ON TABLE public.pf_weekly_balances IS
+  'Week-end balance snapshots for each Profit First account with beginning/ending balances and interim markers.';
+COMMENT ON COLUMN public.pf_weekly_balances.ym IS
+  'Year-month (YYYY-MM) indicating which calendar month the week belongs to.';
+COMMENT ON COLUMN public.pf_weekly_balances.week_end_date IS
+  'The ISO date that marks the end of the represented week.';
+COMMENT ON COLUMN public.pf_weekly_balances.is_interim IS
+  'True when the beginning balance was sourced from a mid-week checkpoint.';
+
+-- Step 3: indexes to support dashboard queries.
+CREATE INDEX idx_pf_weekly_balances_client_ym
+  ON public.pf_weekly_balances (client_id, ym);
+CREATE INDEX idx_pf_weekly_balances_client_week
+  ON public.pf_weekly_balances (client_id, week_end_date);
+
+-- Step 4: updated_at maintenance trigger.
+CREATE OR REPLACE FUNCTION public.touch_pf_weekly_balances_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_touch_pf_weekly_balances_updated_at
+  BEFORE UPDATE ON public.pf_weekly_balances
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_pf_weekly_balances_updated_at();
+
+-- Step 5: expose data through a view.
+CREATE OR REPLACE VIEW public.v_pf_weekly_balances AS
+SELECT
+  client_id,
+  ym,
+  week_end_date,
+  pf_slug,
+  beginning_balance,
+  ending_balance,
+  is_interim
+FROM public.pf_weekly_balances;
+
+GRANT SELECT ON public.v_pf_weekly_balances TO authenticated;


### PR DESCRIPTION
## Summary
- add weekly balance computation with roll-forward validations and updated forecast results
- document and migrate Supabase schema to store weekly balances alongside interim flags
- surface weekly balances and interim controls through dashboard, importer, and settings UI scaffolding

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f50fcd093c832c81b35a3cd4497bbe