### PR TITLE
Refine half-day workshop agenda and host presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,1673 +4,488 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Build the Business You Deserve: Full-Day Intensive (Oct 23)</title>
-  <meta name="description" content="One-day, small-group intensive for business owners. Gain clarity, stop profit leaks, and leave with an action plan. Only 8 seats." />
-  <meta property="og:title" content="Build the Business You Deserve: Full-Day Intensive" />
-  <meta property="og:description" content="One-day, small-group intensive for business owners. Gain clarity, stop profit leaks, and leave with an action plan." />
-  <meta property="og:image" content="https://example.com/og-image.jpg" />
+  <title>2026 Business Reset Workshop — Half-Day Intensive</title>
+  <meta
+    name="description"
+    content="Half-day Profit First reset on Nov 19. Check in at 8:30, work 9–12:30 with Joe Farago & Dave Worden, and leave with a cash-smart 90-day plan for 2026."
+  />
+  <meta property="og:title" content="2026 Business Reset Workshop" />
+  <meta
+    property="og:description"
+    content="Join Joe Farago and Dave Worden for a half-day reset that replaces guesswork with a Profit First plan for 2026."
+  />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://example.com/event" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Build the Business You Deserve: Full-Day Intensive" />
-  <meta name="twitter:description" content="One-day, small-group intensive for business owners. Gain clarity, stop profit leaks, and leave with an action plan." />
-  <meta name="twitter:image" content="https://example.com/og-image.jpg" />
   <link rel="preconnect" href="https://www.paypal.com" />
   <script
     src="https://www.paypal.com/sdk/js?client-id=BAAlzQkr1luPvDKq4oY1XUoyk-u3Wwe8xXXlglYEFlQ6iiHQA3MSQVCn6Dmp2-dOe0FAyfd3tIQbl5oDOk&components=hosted-buttons&enable-funding=venmo&currency=USD"
     crossorigin="anonymous"
     async
   ></script>
-  <!-- GA4: G-XXXXXXX -->
-  <!-- Meta Pixel: 000000000000000 -->
   <style>
     :root {
-      --blue: #004AAD;
-      --orange: #FA9100;
-      --navy: #E9F1FF;
-      --midnight: #050B16;
-      --ink: #0F1A2A;
-      --sky: #F7F9FC;
-      --slate: #A8B7CE;
-      --surface: rgba(18, 34, 58, 0.82);
-      --card: rgba(15, 29, 52, 0.88);
-      --white: #FFFFFF;
-      --radius-lg: 28px;
+      --bg: #f8fbff;
+      --card: #ffffff;
+      --ink: #0f172a;
+      --slate: #334155;
+      --accent: #2563eb;
+      --accent-soft: rgba(37, 99, 235, 0.12);
+      --accent-2: #f97316;
       --radius: 18px;
-      --shadow-lg: 0 32px 120px rgba(3, 7, 18, 0.55);
-      --shadow: 0 20px 60px rgba(8, 17, 35, 0.45);
-      --font-heading: 'Inter', 'Poppins', 'Segoe UI', sans-serif;
-      --font-body: 'Inter', 'Segoe UI', system-ui, sans-serif;
-      --transition: all 0.25s ease;
+      --radius-lg: 26px;
+      --shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+      --font: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
     }
     *, *::before, *::after {
       box-sizing: border-box;
     }
-    html,
-    body {
-      width: 100%;
-      min-height: 100%;
-    }
-    body::before {
-      content: "";
-      position: fixed;
-      inset: 0;
-      background: linear-gradient(rgba(5, 11, 22, 0.8), rgba(5, 11, 22, 0.92)),
-        url('https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=2000&q=70') center/cover no-repeat;
-      opacity: 0.45;
-      z-index: -1;
-      pointer-events: none;
-    }
-    body {
+    html, body {
       margin: 0;
-      font-family: var(--font-body);
-      font-size: 18px;
-      line-height: 1.7;
-      color: var(--navy);
-      background: linear-gradient(135deg, rgba(4, 12, 28, 0.95), rgba(2, 7, 20, 0.98));
+      padding: 0;
+      font-family: var(--font);
+      color: var(--slate);
+      background: var(--bg);
+      line-height: 1.6;
+    }
+    body {
       min-height: 100vh;
-      -webkit-font-smoothing: antialiased;
-      text-align: center;
-      position: relative;
-      overflow-x: hidden;
-    }
-    .event-landing {
-      position: relative;
-      width: 100vw;
-      max-width: 100vw;
-      margin-left: calc(50% - 50vw);
-      min-height: 100vh;
-      overflow: visible;
-      background: linear-gradient(135deg, rgba(4, 12, 28, 0.95), rgba(2, 7, 20, 0.98));
-      isolation: isolate;
-    }
-    .event-landing::before {
-      content: "";
-      position: fixed;
-      inset: 0;
-      background: linear-gradient(rgba(5, 11, 22, 0.8), rgba(5, 11, 22, 0.92)),
-        url('https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=2000&q=70') center/cover no-repeat;
-      opacity: 0.45;
-      z-index: -1;
-      pointer-events: none;
-    }
-    img {
-      max-width: 100%;
-      display: block;
-      height: auto;
-      border-radius: inherit;
-    }
-    a {
-      color: var(--sky);
-      font-weight: 600;
-      text-decoration: none;
-    }
-    a:hover,
-    a:focus {
-      text-decoration: underline;
     }
     h1, h2, h3 {
-      font-family: var(--font-heading);
-      color: var(--sky);
-      margin: 0 0 0.5em;
+      color: var(--ink);
+      font-weight: 700;
       line-height: 1.15;
+      margin: 0 0 0.5em;
     }
     h1 {
-      font-size: clamp(3.6rem, 7vw, 5rem);
-      letter-spacing: -0.025em;
+      font-size: clamp(2.8rem, 6vw, 3.8rem);
+      letter-spacing: -0.02em;
     }
     h2 {
-      font-size: clamp(2.1rem, 4vw, 2.7rem);
+      font-size: clamp(1.9rem, 4vw, 2.4rem);
+      letter-spacing: -0.01em;
     }
     h3 {
-      font-size: clamp(1.3rem, 2.4vw, 1.6rem);
+      font-size: clamp(1.25rem, 3vw, 1.5rem);
     }
     p {
       margin: 0 0 1.2em;
-      color: var(--slate);
-      text-align: center;
     }
-    ul {
-      margin: 0 0 1.5em;
-      padding-left: 1.25em;
+    a {
+      color: inherit;
     }
-    .container {
-      width: min(1180px, 100%);
+    .page-shell {
+      padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 6vw, 4rem) 5rem;
+      max-width: 1080px;
       margin: 0 auto;
-      padding: 5rem clamp(1.5rem, 6vw, 4rem);
-      position: relative;
-      z-index: 1;
+      display: grid;
+      gap: clamp(3.5rem, 8vw, 5rem);
     }
-    .surface {
-      background: var(--surface);
-      border-radius: 32px;
-      border: 1px solid rgba(148, 163, 184, 0.22);
-      box-shadow: var(--shadow-lg);
-      backdrop-filter: blur(18px);
-      position: relative;
-      overflow: hidden;
+    .hero {
+      background: linear-gradient(135deg, #e0ecff, #fff8f2);
+      border-radius: var(--radius-lg);
+      padding: clamp(2.5rem, 6vw, 4rem);
+      box-shadow: var(--shadow);
+      display: grid;
+      gap: 1.75rem;
     }
-    .surface::after {
-      content: "";
-      position: absolute;
-      inset: 1px;
-      border-radius: 31px;
-      background: linear-gradient(135deg, rgba(0, 74, 173, 0.16), rgba(250, 145, 0, 0.08) 45%, transparent);
-      opacity: 0.35;
-      z-index: -1;
-      pointer-events: none;
-    }
-    .surface > * {
-      position: relative;
-      z-index: 2;
-    }
-    .section-title {
-      display: flex;
-      flex-direction: column;
-      gap: 0.6rem;
-      margin-bottom: 2.5rem;
-      align-items: center;
-      text-align: center;
-    }
-    .section-title h2 {
-      text-shadow: 0 22px 60px rgba(0, 0, 0, 0.55);
-      letter-spacing: -0.015em;
-      position: relative;
-    }
-    .section-title h2::after {
-      content: "";
-      width: 120px;
-      height: 4px;
-      border-radius: 999px;
-      background: linear-gradient(90deg, rgba(0, 74, 173, 0.4), rgba(250, 145, 0, 0.65));
-      display: block;
-      margin: 1.2rem auto 0;
-    }
-    .section-kicker {
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.16em;
-      color: var(--orange);
-      font-size: 0.85rem;
+    .hero-kicker {
       display: inline-flex;
       align-items: center;
-      justify-content: center;
-      padding: 0.45rem 1.4rem;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: var(--accent);
+      background: var(--accent-soft);
+      padding: 0.4rem 1.2rem;
       border-radius: 999px;
-      background: rgba(250, 145, 0, 0.16);
-      box-shadow: 0 10px 26px rgba(250, 145, 0, 0.25);
+    }
+    .hero-details {
+      display: grid;
+      gap: 0.85rem;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+    .detail-card {
+      background: rgba(255, 255, 255, 0.65);
+      border-radius: var(--radius);
+      padding: 1rem 1.2rem;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      font-weight: 600;
+      display: grid;
+      gap: 0.4rem;
+    }
+    .detail-card span {
+      font-size: 0.9rem;
+      font-weight: 500;
+      color: rgba(15, 23, 42, 0.68);
+    }
+    .cta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: center;
     }
     .btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: 1rem 2.1rem;
-      border-radius: 16px;
-      border: 2px solid transparent;
+      padding: 0.95rem 1.9rem;
+      border-radius: 999px;
       font-weight: 700;
-      font-size: 1.05rem;
-      cursor: pointer;
-      box-shadow: none;
-      transition: var(--transition);
       text-decoration: none;
-      min-width: 190px;
-    }
-    .btn:focus-visible {
-      outline: 3px solid var(--orange);
-      outline-offset: 3px;
+      border: 2px solid transparent;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      cursor: pointer;
     }
     .btn-primary {
-      background: var(--blue);
-      color: var(--white);
-      box-shadow: 0 14px 34px rgba(0, 74, 173, 0.28);
+      background: var(--ink);
+      color: #fff;
+      box-shadow: 0 12px 26px rgba(15, 23, 42, 0.25);
     }
     .btn-primary:hover,
-    .btn-primary:focus {
+    .btn-primary:focus-visible {
       transform: translateY(-2px);
-      box-shadow: 0 20px 40px rgba(0, 74, 173, 0.35);
-    }
-    .btn.cta-highlight {
-      position: relative;
-      overflow: hidden;
-      background: linear-gradient(120deg, rgba(0, 74, 173, 1), rgba(250, 145, 0, 0.95));
-      border-color: transparent;
-      color: var(--white);
-      box-shadow: 0 20px 48px rgba(0, 74, 173, 0.35);
-      animation: ctaPulse 4s ease-in-out infinite;
-    }
-    .btn.cta-highlight::before {
-      content: "";
-      position: absolute;
-      inset: -120% -30%;
-      background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.55), transparent);
-      transform: rotate(25deg);
-      animation: ctaSheen 5s linear infinite;
-      pointer-events: none;
-    }
-    .btn.cta-highlight:hover,
-    .btn.cta-highlight:focus {
-      box-shadow: 0 24px 58px rgba(0, 74, 173, 0.45);
+      box-shadow: 0 18px 34px rgba(15, 23, 42, 0.28);
     }
     .btn-secondary {
       background: transparent;
-      color: var(--sky);
-      border-color: rgba(255, 255, 255, 0.35);
+      color: var(--ink);
+      border-color: rgba(15, 23, 42, 0.18);
     }
     .btn-secondary:hover,
-    .btn-secondary:focus {
-      background: rgba(255, 255, 255, 0.08);
+    .btn-secondary:focus-visible {
+      border-color: var(--ink);
+      transform: translateY(-2px);
     }
-    .hero {
-      display: flex;
-      flex-direction: column;
-      gap: 2.75rem;
-      padding-top: 6.5rem;
-      color: var(--sky);
-      align-items: center;
-      justify-content: center;
-    }
-    .hero-content {
-      display: flex;
-      flex-direction: column;
-      gap: 1.75rem;
-      align-items: center;
-      width: 100%;
-    }
-    .hero-title {
-      display: inline-block;
-      padding: 0.35rem 1.5rem;
-      border-radius: 42px;
-      background: linear-gradient(135deg, rgba(0, 74, 173, 0.32), rgba(250, 145, 0, 0.22));
-      box-shadow: 0 42px 120px rgba(0, 0, 0, 0.6);
-      text-shadow: 0.1em 0.1em 0 rgba(1, 15, 40, 0.88), 0.2em 0.2em 0 rgba(0, 74, 173, 0.35), 0.32em 0.32em 0 rgba(0, 26, 64, 0.25);
-    }
-    .hero-kicker {
-      font-weight: 700;
-      color: var(--orange);
-      text-transform: uppercase;
-      letter-spacing: 0.16em;
-      font-size: 0.82rem;
-    }
-    .hero-sub {
-      font-size: clamp(1.2rem, 3vw, 1.4rem);
-      color: rgba(232, 240, 255, 0.86);
-      max-width: 880px;
-      margin: 0 auto;
-    }
-    .badge-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-      justify-content: center;
-    }
-    .badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      background: rgba(0, 74, 173, 0.28);
-      color: var(--sky);
-      padding: 0.55rem 1.25rem;
-      border-radius: 999px;
-      font-weight: 600;
-      font-size: 0.95rem;
-      box-shadow: 0 12px 26px rgba(0, 74, 173, 0.32);
-    }
-    .badge.orange {
-      background: rgba(250, 145, 0, 0.22);
-      color: #FFE1B0;
-      box-shadow: 0 12px 26px rgba(250, 145, 0, 0.3);
-    }
-    .hero-ctas {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 1rem;
-      justify-content: center;
-    }
-    .hero-trust {
-      font-size: 0.95rem;
-      font-weight: 600;
-      color: rgba(232, 240, 255, 0.78);
-    }
-    .hero-visual {
+    .section {
       background: var(--card);
       border-radius: var(--radius-lg);
-      padding: 1.5rem;
-      box-shadow: var(--shadow-lg);
-      position: relative;
-      overflow: hidden;
-      border: 1px solid rgba(148, 163, 184, 0.18);
-      animation: float 16s ease-in-out infinite;
-      width: min(960px, 100%);
-    }
-    .hero-visual::before {
-      content: "";
-      position: absolute;
-      inset: 8% 8% auto 8%;
-      height: 52%;
-      background: radial-gradient(circle at center, rgba(250, 145, 0, 0.35), transparent 72%);
-      z-index: 0;
-      filter: blur(26px);
-    }
-    .hero-visual img {
-      border-radius: calc(var(--radius-lg) - 8px);
-      position: relative;
-      z-index: 1;
-      object-fit: cover;
-      min-height: 100%;
-    }
-    .countdown-block {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-      margin-top: 1.5rem;
-    }
-    .timer {
-      display: grid;
-      grid-template-columns: repeat(4, minmax(90px, 1fr));
-      gap: 1rem;
-    }
-    .timer-box {
-      background: var(--card);
-      border-radius: 20px;
-      padding: 1rem 1.2rem;
-      text-align: center;
+      padding: clamp(2.4rem, 5vw, 3rem);
       box-shadow: var(--shadow);
-      border: 1px solid rgba(148, 163, 184, 0.18);
-    }
-    .timer-box strong {
-      font-size: 1.9rem;
-      display: block;
-      font-family: var(--font-heading);
-      color: var(--sky);
-    }
-    .countdown-note {
-      font-size: 0.95rem;
-      color: rgba(232, 240, 255, 0.75);
-      font-weight: 600;
-    }
-    .countdown-note span {
-      color: var(--orange);
-    }
-    .pains-intro {
-      max-width: 720px;
-      margin: 0 auto 2rem;
-      color: rgba(232, 240, 255, 0.85);
-      font-weight: 600;
-    }
-    .pains-list {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.75rem;
-      list-style: none;
-      padding: 0;
-    }
-    .pain-card {
-      position: relative;
-      width: 100%;
-      border-radius: 26px;
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(148, 163, 184, 0.18);
-      box-shadow: 0 28px 70px rgba(2, 6, 18, 0.55);
-      cursor: pointer;
-      display: flex;
-      flex-direction: column;
-      gap: 1.25rem;
-      padding: 2.1rem 2.2rem;
-      text-align: center;
-      transition: box-shadow 0.35s ease, border-color 0.35s ease, transform 0.35s ease;
-      background-image: radial-gradient(circle at 20% -10%, rgba(250, 145, 0, 0.25), transparent 55%),
-        linear-gradient(145deg, rgba(8, 18, 38, 0.92), rgba(0, 74, 173, 0.18));
-    }
-    .pain-card:hover,
-    .pain-card:focus-visible,
-    .pain-card.open {
-      box-shadow: 0 36px 90px rgba(0, 0, 0, 0.6);
-      border-color: rgba(250, 145, 0, 0.4);
-      transform: translateY(-4px);
-    }
-    .pain-card:focus-visible {
-      outline: 3px solid var(--orange);
-      outline-offset: 4px;
-    }
-    .pain-card-question {
-      color: var(--sky);
-      font-weight: 700;
-      font-size: 1.15rem;
-      line-height: 1.45;
-    }
-    .pain-card-answer {
-      color: rgba(232, 240, 255, 0.88);
-      font-size: 1.05rem;
-      line-height: 1.65;
-      overflow: hidden;
-      max-height: 0;
-      transition: max-height 0.45s ease, opacity 0.35s ease;
-      opacity: 0;
-    }
-    .pain-card.open .pain-card-answer {
-      opacity: 1;
-    }
-    .outcomes {
-      display: grid;
-      gap: 3rem;
-    }
-    .outcomes-grid {
-      display: grid;
-      gap: 2.5rem;
-      align-items: center;
-      justify-items: center;
-    }
-    .outcome-accordions {
-      display: grid;
-      gap: 1.2rem;
-      width: 100%;
-      max-width: 700px;
-      margin: 0 auto;
-    }
-    .outcome-item {
-      background: rgba(255, 255, 255, 0.05);
-      border-radius: 22px;
-      border: 1px solid rgba(148, 163, 184, 0.16);
-      box-shadow: 0 24px 55px rgba(4, 10, 24, 0.55);
-      overflow: hidden;
-      transition: var(--transition);
-    }
-    .outcome-item.open {
-      border-color: rgba(250, 145, 0, 0.4);
-      box-shadow: 0 32px 70px rgba(250, 145, 0, 0.18);
-    }
-    .outcome-toggle {
-      width: 100%;
-      background: transparent;
-      border: none;
-      color: var(--sky);
-      font-family: var(--font-heading);
-      font-size: 1.1rem;
-      font-weight: 700;
-      padding: 1.2rem 1.6rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1.2rem;
-      cursor: pointer;
-      text-align: left;
-    }
-    .outcome-toggle span {
-      flex: 1;
-    }
-    .outcome-toggle svg {
-      width: 24px;
-      height: 24px;
-      stroke: var(--orange);
-      stroke-width: 2;
-      fill: none;
-      transition: var(--transition);
-    }
-    .outcome-item.open .outcome-toggle svg {
-      transform: rotate(180deg);
-    }
-    .outcome-content {
-      padding: 0 1.6rem 1.4rem;
-      max-height: 0;
-      overflow: hidden;
-      transition: max-height 0.35s ease;
-    }
-    .outcome-content p {
-      margin: 0;
-      color: rgba(232, 240, 255, 0.85);
-      text-align: left;
-    }
-    .mini-proof {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.6rem;
-      margin-top: 0.8rem;
-      font-weight: 600;
-      color: var(--slate);
-      justify-content: center;
-    }
-    .mini-proof span {
-      background: rgba(250, 145, 0, 0.16);
-      color: var(--orange);
-      padding: 0.4rem 0.8rem;
-      border-radius: 999px;
-      font-size: 0.9rem;
-    }
-    .mentors-grid {
       display: grid;
       gap: 2rem;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      justify-items: center;
     }
-    .mentor-card {
-      background: rgba(255, 255, 255, 0.05);
-      border-radius: 26px;
-      padding: 2.2rem;
-      box-shadow: var(--shadow);
-      border: 1px solid rgba(148, 163, 184, 0.16);
+    .section-header {
       display: grid;
-      gap: 1.4rem;
-      max-width: 520px;
+      gap: 0.6rem;
+    }
+    .section-header span {
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+      font-size: 0.78rem;
+      font-weight: 700;
+      color: rgba(15, 23, 42, 0.55);
+    }
+    .grid-cards {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+    .card {
+      border-radius: var(--radius);
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      padding: 1.6rem;
+      display: grid;
+      gap: 0.75rem;
+      background: #fff;
+    }
+    .card strong {
+      color: var(--ink);
+      font-size: 1.05rem;
+    }
+    .timeline {
+      display: grid;
+      gap: 1rem;
+    }
+    .timeline-item {
+      display: flex;
+      gap: 1.2rem;
+      align-items: flex-start;
+      padding: 1rem 1.2rem;
+      border-radius: var(--radius);
+      border: 1px solid rgba(37, 99, 235, 0.18);
+      background: rgba(37, 99, 235, 0.04);
+    }
+    .timeline-time {
+      font-weight: 700;
+      color: var(--accent);
+      min-width: 90px;
+    }
+    .hosts {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+    .host-card {
+      border-radius: var(--radius);
+      padding: 1.8rem;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      background: linear-gradient(145deg, #ffffff, #f1f5ff);
+      display: grid;
+      gap: 0.75rem;
+      justify-items: center;
       text-align: center;
-      transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
     }
-    .mentor-card:hover,
-    .mentor-card:focus-within {
-      transform: translateY(-8px);
-      border-color: rgba(250, 145, 0, 0.35);
-      box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55);
-    }
-    .mentor-avatar {
-      width: 140px;
-      height: 140px;
+    .host-portrait {
+      width: 100%;
+      max-width: 120px;
+      aspect-ratio: 1;
       border-radius: 50%;
-      margin: 0 auto;
       overflow: hidden;
-      box-shadow: 0 28px 70px rgba(0, 0, 0, 0.55);
-      border: 3px solid rgba(250, 145, 0, 0.4);
+      box-shadow: 0 12px 22px rgba(15, 23, 42, 0.18);
     }
-    .mentor-avatar img {
+    .host-portrait img {
       width: 100%;
       height: 100%;
       object-fit: cover;
-      display: block;
     }
-    .mentor-name {
-      font-size: 1.6rem;
-      color: var(--sky);
-      margin-bottom: 0.4rem;
-    }
-    .mentor-role {
-      color: rgba(250, 145, 0, 0.85);
+    .host-name {
+      font-size: 1.2rem;
       font-weight: 700;
-      letter-spacing: 0.12em;
+      color: var(--ink);
+    }
+    .host-role {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: rgba(15, 23, 42, 0.6);
       text-transform: uppercase;
-      font-size: 0.82rem;
+      letter-spacing: 0.14em;
     }
-    .mentor-bio {
-      color: rgba(232, 240, 255, 0.85);
-    }
-    .details-shell {
-      display: block;
-    }
-    .details-card {
-      background: rgba(255, 255, 255, 0.05);
-      border-radius: 28px;
-      padding: clamp(2rem, 4vw, 3rem);
-      box-shadow: var(--shadow);
-      border: 1px solid rgba(148, 163, 184, 0.14);
+    .value-callout {
+      border-radius: var(--radius);
+      padding: 1.6rem;
+      border: 1px solid rgba(249, 115, 22, 0.22);
+      background: rgba(249, 115, 22, 0.05);
       display: grid;
-      gap: 1.6rem;
+      gap: 0.5rem;
     }
-    .details-grid {
+    .register-box {
+      border-radius: var(--radius-lg);
+      padding: clamp(2rem, 5vw, 2.8rem);
+      background: #0f172a;
+      color: #e2e8f0;
       display: grid;
       gap: 1.2rem;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      text-align: center;
     }
-    .details-card ul {
+    .register-box h2 {
+      color: #fff;
+      margin-bottom: 0.4rem;
+    }
+    .register-box p {
       margin: 0;
-      padding: 0;
-      list-style: none;
-      display: grid;
-      gap: 0.4rem;
-      color: var(--sky);
-      font-weight: 600;
-      text-align: center;
     }
-    .details-card li {
-      display: grid;
-      gap: 0.25rem;
-      text-align: center;
+    .price-tag {
+      font-size: clamp(2rem, 6vw, 2.6rem);
+      font-weight: 800;
+      color: #fff;
     }
-    .details-card strong {
-      color: var(--sky);
-    }
-    .details-card li span {
-      display: block;
-      font-weight: 400;
-      color: var(--slate);
-      text-align: center;
-    }
-    .details-countdown {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 1rem;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      background: rgba(255, 255, 255, 0.04);
-      border-radius: 20px;
-      padding: 1.25rem 1.5rem;
-      border: 1px solid rgba(148, 163, 184, 0.1);
-      color: var(--sky);
-    }
-    .details-countdown .btn {
-      flex-shrink: 0;
-    }
-    .details-countdown strong {
-      font-size: 1.1rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: rgba(250, 145, 0, 0.86);
-    }
-    .details-cta {
-      margin-top: 2.5rem;
-      display: flex;
-      justify-content: center;
-    }
-    .testimonial-collage {
-      display: grid;
-      gap: 1.75rem;
-      overflow: hidden;
-    }
-    .collage-track {
-      display: flex;
-      gap: 1.5rem;
-      width: max-content;
-      animation: marquee 28s linear infinite;
-    }
-    .collage-track.reverse {
-      animation-direction: reverse;
-      animation-duration: 32s;
-    }
-    .testimonial-chip {
-      flex: 0 0 320px;
-      padding: 1.6rem;
-      border-radius: 24px;
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(148, 163, 184, 0.18);
-      box-shadow: 0 24px 55px rgba(0, 0, 0, 0.35);
-      display: grid;
-      gap: 1rem;
-      color: var(--sky);
-    }
-    .testimonial-quote {
-      font-size: 1rem;
-      line-height: 1.6;
-      color: rgba(232, 240, 255, 0.9);
-    }
-    .testimonial-author {
-      display: grid;
-      gap: 0.3rem;
-    }
-    .testimonial-author strong {
-      color: var(--sky);
-      font-size: 0.95rem;
-    }
-    .testimonial-author span {
-      color: rgba(232, 240, 255, 0.7);
-      font-size: 0.9rem;
-    }
-    .faq {
-      display: grid;
-      gap: 1rem;
-    }
-    .faq-item {
-      background: rgba(255, 255, 255, 0.05);
-      border-radius: 20px;
-      border: 1px solid rgba(148, 163, 184, 0.18);
-      box-shadow: 0 22px 45px rgba(2, 7, 20, 0.55);
-      overflow: hidden;
-      transition: var(--transition);
-    }
-    .faq-item.open {
-      border-color: rgba(250, 145, 0, 0.45);
-      box-shadow: 0 28px 60px rgba(250, 145, 0, 0.18);
-    }
-    .faq-question {
-      width: 100%;
-      background: transparent;
-      border: none;
-      color: var(--sky);
-      font-family: inherit;
-      font-weight: 700;
-      font-size: 1.05rem;
-      padding: 1.35rem 1.6rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1.5rem;
-      cursor: pointer;
-    }
-    .faq-question span {
-      flex: 1;
-      text-align: left;
-    }
-    .faq-question svg {
-      width: 20px;
-      height: 20px;
-      transition: transform 0.3s ease;
-      fill: none;
-      stroke: rgba(232, 240, 255, 0.7);
-      stroke-width: 2;
-    }
-    .faq-item.open .faq-question svg {
-      transform: rotate(180deg);
-      stroke: rgba(250, 145, 0, 0.9);
-    }
-    .faq-question:focus-visible {
-      outline: 3px solid var(--orange);
-      outline-offset: 3px;
-    }
-    .faq-answer {
-      max-height: 0;
-      overflow: hidden;
-      transition: max-height 0.35s ease, padding 0.35s ease;
-      padding: 0 1.6rem;
-    }
-    .faq-item.open .faq-answer {
-      padding-bottom: 1.4rem;
-    }
-    .faq-answer p {
-      color: rgba(232, 240, 255, 0.78);
-      margin-bottom: 0;
-      text-align: left;
-    }
-    .register {
-      padding: 5rem 0;
-      background: #f3f4f6;
-      color: var(--ink);
-      text-align: center;
-    }
-    .register .container {
-      padding: 0 clamp(1.5rem, 6vw, 4rem);
-    }
-    .register-shell {
-      margin: 0 auto;
-      max-width: 760px;
-      background: var(--white);
-      border-radius: 26px;
-      border: 1px solid rgba(15, 26, 42, 0.08);
-      box-shadow: 0 26px 60px rgba(15, 26, 42, 0.12);
-      padding: clamp(2rem, 5vw, 3rem);
-      display: grid;
-      gap: 1.5rem;
-    }
-    .register h2 {
-      color: var(--ink);
-    }
-    .register p {
-      color: rgba(15, 26, 42, 0.75);
-    }
-    .register .sub {
-      color: rgba(15, 26, 42, 0.85);
-      margin-bottom: 0.5rem;
-      font-weight: 600;
-    }
-    .register .sub strong {
-      color: var(--blue);
-    }
-    .register .micro {
-      font-size: 0.95rem;
-      color: rgba(15, 26, 42, 0.7);
-      margin-bottom: 1.25rem;
-    }
-    .checkout-frame {
-      border-radius: 20px;
-      border: 1px solid rgba(15, 26, 42, 0.08);
-      background: #f3f4f6;
-      padding: clamp(1.5rem, 4vw, 2rem);
-      display: grid;
-      gap: 1rem;
-      text-align: center;
-    }
-    .checkout-frame iframe {
-      width: 100%;
-      min-height: 620px;
-      border: 0;
-      border-radius: 12px;
-      background: #fff;
-      box-shadow: inset 0 0 0 1px rgba(15, 26, 42, 0.08);
-    }
-    .checkout-frame .checkout-help {
-      margin: 0;
-      color: rgba(15, 26, 42, 0.65);
-      font-weight: 600;
-      letter-spacing: 0.01em;
-    }
-    .checkout-frame .checkout-help a {
-      color: var(--blue);
+    .paypal-wrap {
+      background: rgba(15, 23, 42, 0.6);
+      border-radius: var(--radius);
+      padding: 1.4rem;
     }
     footer {
-      background: rgba(5, 11, 22, 0.92);
-      padding: 2.5rem 0;
-      font-size: 0.95rem;
-      color: rgba(232, 240, 255, 0.7);
-      border-top: 1px solid rgba(148, 163, 184, 0.22);
-    }
-    footer .footer-inner {
-      width: min(1180px, 100%);
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      flex-wrap: wrap;
-      gap: 1.5rem;
-      justify-content: center;
-      align-items: center;
       text-align: center;
-      padding: 0 clamp(1.5rem, 6vw, 4rem);
-    }
-    footer .footer-inner > div {
-      max-width: 720px;
-      width: 100%;
-    }
-    footer a {
-      color: var(--sky);
-    }
-    footer strong {
-      color: var(--sky);
-    }
-    .sticky-footer {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      display: none;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      padding: 0.85rem 1rem;
-      background: rgba(15, 26, 42, 0.96);
-      color: var(--white);
-      z-index: 999;
-      box-shadow: 0 -8px 18px rgba(15, 26, 42, 0.25);
-    }
-    .sticky-footer p {
-      margin: 0;
-      font-weight: 700;
-      font-size: 0.95rem;
-    }
-    .sticky-footer .btn-primary {
-      min-width: 160px;
-    }
-    .micro-cta {
-      font-size: 0.95rem;
-      color: rgba(232, 240, 255, 0.78);
-      text-align: center;
-      margin-top: 1.5rem;
-    }
-    .micro-cta a {
-      color: var(--sky);
-    }
-    .pain-cta {
-      margin: 2.5rem auto 0;
-    }
-    @media (min-width: 980px) {
-      footer .footer-inner {
-        flex-direction: row;
-        justify-content: center;
-        gap: 3rem;
-      }
-      footer .footer-inner > div {
-        max-width: 520px;
-        width: auto;
-      }
-    }
-    @keyframes ctaPulse {
-      0%, 100% {
-        transform: translateY(0) scale(1);
-        box-shadow: 0 20px 48px rgba(0, 74, 173, 0.35);
-      }
-      50% {
-        transform: translateY(-4px) scale(1.03);
-        box-shadow: 0 28px 60px rgba(250, 145, 0, 0.38);
-      }
-    }
-    @keyframes ctaSheen {
-      0% {
-        transform: translateX(-60%) rotate(25deg);
-      }
-      100% {
-        transform: translateX(60%) rotate(25deg);
-      }
-    }
-    .collage-track:hover {
-      animation-play-state: paused;
-    }
-    @keyframes float {
-      0%, 100% {
-        transform: translateY(0px) scale(1);
-      }
-      50% {
-        transform: translateY(-12px) scale(1.02);
-      }
-    }
-    @keyframes marquee {
-      0% {
-        transform: translateX(0);
-      }
-      100% {
-        transform: translateX(-50%);
-      }
-    }
-    @media (max-width: 900px) {
-      .hero {
-        padding-top: 5rem;
-      }
-    }
-    @media (max-width: 768px) {
-      .container {
-        padding: clamp(3.5rem, 8vw, 4rem) clamp(1.25rem, 6vw, 2rem);
-      }
-      .hero-ctas {
-        width: 100%;
-      }
-      .hero-ctas .btn {
-        flex: 1 1 160px;
-      }
-      .pain-card {
-        min-height: 200px;
-      }
-      .timer {
-        grid-template-columns: repeat(2, minmax(120px, 1fr));
-      }
-      body,
-      .event-landing {
-        padding-bottom: 78px;
-      }
-      .sticky-footer {
-        display: flex;
-      }
+      color: rgba(15, 23, 42, 0.55);
+      font-size: 0.9rem;
+      padding-bottom: 2rem;
     }
     @media (max-width: 640px) {
-      .surface {
-        border-radius: 24px;
-      }
-      .surface::after {
-        border-radius: 23px;
-      }
-      .hero {
-        gap: 2.25rem;
-        align-items: stretch;
-      }
-      .hero-content {
-        align-items: flex-start;
-        text-align: left;
-        gap: 1.5rem;
-      }
-      .hero-title {
-        font-size: clamp(2.4rem, 9vw, 3rem);
-        text-align: left;
-        align-self: stretch;
-      }
-      .hero-sub,
-      .hero-trust {
-        text-align: left;
-      }
-      .badge-row {
-        justify-content: flex-start;
-      }
-      .hero-ctas {
-        justify-content: flex-start;
-        flex-direction: column;
-        align-items: stretch;
-        gap: 0.75rem;
-      }
-      .hero-ctas .btn {
-        flex: 1 1 auto;
-        width: 100%;
-      }
-      .surface p,
-      .register p,
-      footer p {
-        text-align: left;
-      }
-      .details-countdown {
+      .cta-row {
         flex-direction: column;
         align-items: stretch;
       }
-      .details-countdown .btn {
+      .btn {
         width: 100%;
       }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after {
-        animation-duration: 0.001ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.001ms !important;
-        scroll-behavior: auto !important;
+      .timeline-item {
+        flex-direction: column;
       }
-      .hero-visual,
-      .collage-track,
-      .pain-card,
-      .btn.cta-highlight {
-        animation: none !important;
-      }
-      .pain-card {
-        transition: none !important;
-        transform: none !important;
+      .timeline-time {
+        min-width: auto;
       }
     }
   </style>
 </head>
 <body>
-  <div class="event-landing" id="ghl-event-landing">
-  <main id="top">
-    <section class="hero container surface" aria-labelledby="hero-heading">
-      <div class="hero-content">
-        <span class="hero-kicker">From overwhelmed to in control</span>
-        <h1 id="hero-heading" class="hero-title">Build the Business You Deserve</h1>
-        <p class="hero-sub">One day. Eight seats. Walk in with questions—walk out with clarity, focus, and a plan you can put to work immediately.</p>
-        <div class="badge-row" role="list" aria-label="Event highlights">
-          <span class="badge">Oct 23 • North Ridgeville</span>
-          <span class="badge orange">Only <span data-seat-pill>8</span> Seats</span>
+  <main class="page-shell">
+    <section class="hero" aria-labelledby="hero-title">
+      <span class="hero-kicker">Half-Day Reset • November 19</span>
+      <h1 id="hero-title">From overwhelmed to in control — in one morning.</h1>
+      <p>Theme: <strong>Clarity &amp; Growth.</strong> Work alongside Joe Farago and Dave Worden to rebuild your Profit First system, map revenue plays, and script your 90-day reset for 2026.</p>
+      <div class="hero-details">
+        <div class="detail-card">
+          8:30 – 9:00 AM
+          <span>Check-in, light breakfast &amp; networking</span>
         </div>
-        <div class="hero-ctas">
-          <a class="btn btn-primary cta-highlight" data-cta="hero-primary" href="#register">Reserve My Seat</a>
-          <a class="btn btn-secondary" data-cta="hero-secondary" href="#outcomes">See What You’ll Get</a>
+        <div class="detail-card">
+          9:00 AM – 12:30 PM
+          <span>ActionCOACH North Ridgeville</span>
         </div>
-        <p class="hero-trust">Breakfast + lunch included • Secure checkout • Payment plans available</p>
-        <div class="countdown-block">
-          <div class="countdown-note" id="countdown-note">Future you is cheering you on.</div>
-          <div class="timer" role="timer" aria-label="Countdown to event" id="countdown">
-            <div class="timer-box"><strong id="days">0</strong><span>Days</span></div>
-            <div class="timer-box"><strong id="hours">0</strong><span>Hours</span></div>
-            <div class="timer-box"><strong id="minutes">0</strong><span>Minutes</span></div>
-            <div class="timer-box"><strong id="seconds">0</strong><span>Seconds</span></div>
+        <div class="detail-card">
+          $397 per owner
+          <span>Payment plans available</span>
+        </div>
+        <div class="detail-card">
+          Only 10 seats
+          <span>Hands-on working session</span>
+        </div>
+      </div>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="#register">Reserve my seat</a>
+        <a class="btn btn-secondary" href="#agenda">See the morning flow</a>
+      </div>
+      <p style="font-weight:600; margin:0;">Hosted by ActionCOACH + Triumph Business Solutions</p>
+    </section>
+
+    <section class="section" aria-labelledby="why-title">
+      <div class="section-header">
+        <span>Why this morning matters</span>
+        <h2 id="why-title">Leave guesswork behind and step into 2026 with control.</h2>
+      </div>
+      <div class="grid-cards">
+        <div class="card">
+          <strong>Reset your cash decisions.</strong>
+          <p>Clarify where every dollar belongs so you can pay yourself, fund growth, and breathe again.</p>
+        </div>
+        <div class="card">
+          <strong>Map the money engine.</strong>
+          <p>Sketch your Business Revenue Model to see what fuels profit and what quietly drains capacity.</p>
+        </div>
+        <div class="card">
+          <strong>Launch your next 90 days.</strong>
+          <p>Walk out with prioritized moves and metrics that keep you accountable well past the workshop.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="agenda" class="section" aria-labelledby="agenda-title">
+      <div class="section-header">
+        <span>The morning flow</span>
+        <h2 id="agenda-title">Four hours of clarity, strategy, and action.</h2>
+      </div>
+      <div class="timeline">
+        <div class="timeline-item">
+          <div class="timeline-time">8:30</div>
+          <div>
+            <strong>Check-in &amp; Coffee</strong>
+            <p>Doors open, grab breakfast, and connect with fellow owners before we dive in.</p>
           </div>
-          <p class="countdown-note" id="countdown-message">Oct 23 • Only 8 seats • $997</p>
         </div>
-        <div class="hero-visual" aria-hidden="true">
-          <img src="https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=1600&q=80" alt="Business owners collaborating with a coach during a strategy workshop" loading="lazy" />
+        <div class="timeline-item">
+          <div class="timeline-time">9:00</div>
+          <div>
+            <strong>Introductions &amp; framing (10–15 min)</strong>
+            <p>Welcome from Joe &amp; Dave, attendee intros, and how financial clarity + growth strategy lock together.</p>
+          </div>
+        </div>
+        <div class="timeline-item">
+          <div class="timeline-time">9:15</div>
+          <div>
+            <strong>Session 1 – Triumph: Profit First Systems (60 min)</strong>
+            <p>Why cash beats sales, the 5 core accounts, owner’s pay targets, and a hands-on Profit First assessment to spot your leaks.</p>
+          </div>
+        </div>
+        <div class="timeline-item">
+          <div class="timeline-time">10:15</div>
+          <div>
+            <strong>Session 2 – ActionCOACH: Strategy &amp; Growth (90 min)</strong>
+            <p>Mindset reset, the 6 Steps scorecard, 5 Ways to grow profit by 61%, plus the Green Sheet for time management.</p>
+          </div>
+        </div>
+        <div class="timeline-item">
+          <div class="timeline-time">11:45</div>
+          <div>
+            <strong>Session 3 – Triumph: Business Money Models (45 min)</strong>
+            <p>Map the 3 phases of your money system and build Phase 1: Awareness so revenue flows on purpose.</p>
+          </div>
+        </div>
+        <div class="timeline-item">
+          <div class="timeline-time">12:15</div>
+          <div>
+            <strong>Wrap-Up &amp; Next Steps (15 min)</strong>
+            <p>Recap the wins, secure your diagnostic with Joe, and choose how to roll into The Owner’s Advantage Program.</p>
+          </div>
         </div>
       </div>
     </section>
 
-    <section id="pains" class="container surface" aria-labelledby="pains-heading">
-      <div class="section-title">
-        <span class="section-kicker">Let's be real</span>
-        <h2 id="pains-heading">Do any of these hit home?</h2>
+    <section class="section" aria-labelledby="hosts-title">
+      <div class="section-header">
+        <span>Your guides</span>
+        <h2 id="hosts-title">Built for owners by coaches who live this work.</h2>
       </div>
-      <p class="pains-intro">Our program is right for you if you answer <strong>yes</strong> to one or more of these questions.</p>
-      <ul class="pains-list">
-        <li class="pain-item">
-          <button class="pain-card" type="button" aria-expanded="false">
-            <span class="pain-card-question">Are you still paying yourself last while everyone else gets paid first?</span>
-            <span class="pain-card-answer">You’ll learn a simple system to pay yourself first—without starving the business. We’ll help you redesign your cash routine so every dollar has a purpose, and your personal income becomes a non-negotiable priority.</span>
-          </button>
-        </li>
-        <li class="pain-item">
-          <button class="pain-card" type="button" aria-expanded="false">
-            <span class="pain-card-question">Is “growth” piling on chaos faster than it creates real freedom?</span>
-            <span class="pain-card-answer">We’ll help you structure your business to grow with control, not confusion. You’ll learn how to focus on the right levers and eliminate the noise so growth starts creating freedom, not more fires to fight.</span>
-          </button>
-        </li>
-        <li class="pain-item">
-          <button class="pain-card" type="button" aria-expanded="false">
-            <span class="pain-card-question">Are you making big decisions with numbers you don’t fully trust?</span>
-            <span class="pain-card-answer">You’ll leave with a process to finally trust your numbers. Our framework helps you see exactly what’s coming, what’s safe to spend, and how to make confident choices based on facts—not gut feelings.</span>
-          </button>
-        </li>
-        <li class="pain-item">
-          <button class="pain-card" type="button" aria-expanded="false">
-            <span class="pain-card-question">Does your team feel slammed while profit still stays flat?</span>
-            <span class="pain-card-answer">You’ll uncover the real reasons effort isn’t turning into results. We’ll help you identify bottlenecks, align your operations with profitability, and make sure your team’s hard work actually drives progress.</span>
-          </button>
-        </li>
-        <li class="pain-item">
-          <button class="pain-card" type="button" aria-expanded="false">
-            <span class="pain-card-question">Are you stuck saying “yes” to work that drains your energy and margin?</span>
-            <span class="pain-card-answer">We’ll show you how to define clear boundaries, price for value, and build a model that supports both your profit and your sanity. You’ll learn to say “yes” only to what truly moves your business forward.</span>
-          </button>
-        </li>
-        <li class="pain-item">
-          <button class="pain-card" type="button" aria-expanded="false">
-            <span class="pain-card-question">If nothing changed in 90 days, would the stress cost more than this investment?</span>
-            <span class="pain-card-answer">This day is your chance to break that cycle. We’ll help you build the clarity, control, and confidence to finally stop spinning your wheels—and start running a business that serves you.</span>
-          </button>
-        </li>
-      </ul>
-      <a class="btn btn-primary cta-highlight pain-cta" href="#register" data-cta="pains-inline">I’m ready to fix this</a>
-    </section>
-
-
-    <section id="mentors" class="container surface" aria-labelledby="mentors-heading">
-      <div class="section-title">
-        <span class="section-kicker">Meet your mentors</span>
-        <h2 id="mentors-heading">Guides who live this work every day</h2>
-      </div>
-      <div class="mentors-grid">
-        <article class="mentor-card">
-          <div class="mentor-avatar">
+      <div class="hosts">
+        <article class="host-card">
+          <div class="host-portrait">
             <img src="https://storage.googleapis.com/msgsndr/TANiDRdtEe5RXuoDL25H/media/687f7d89bf6969483915197e.png" alt="Portrait of Dave Worden" loading="lazy" />
           </div>
-          <div>
-            <h3 class="mentor-name">Dave Worden</h3>
-            <p class="mentor-role">Founder, Triumph Business Solutions</p>
-          </div>
-          <p class="mentor-bio">Dave is the founder of Triumph Business Solutions, a fractional finance and growth strategy firm dedicated to ending entrepreneurial cash stress. As a Certified Profit First Professional and architect of the Profit First Cash Clarity™ system, Dave helps business owners transform chaos into clarity—creating profitable, predictable growth while paying themselves first.</p>
-          <p class="mentor-bio">With a background in financial strategy, behavioral finance, and business model design, Dave brings a pragmatic yet empowering approach to small-business leadership. Through Triumph's Profit First Cash Clarity and Business Revenue Models programs, he has helped dozens of owners turn uncertainty into structure and stress into strategy.</p>
-          <p class="mentor-bio">When not building better business systems, Dave is probably mapping out new ways to simplify the complex world of money and business—one confident entrepreneur at a time.</p>
+          <div class="host-role">Profit First Mastery</div>
+          <div class="host-name">Dave Worden</div>
+          <p>Founder of Triumph Business Solutions. Known for turning messy financials into simple, repeatable systems that owners actually use.</p>
         </article>
-        <article class="mentor-card">
-          <div class="mentor-avatar">
+        <article class="host-card">
+          <div class="host-portrait">
             <img src="https://storage.googleapis.com/msgsndr/TANiDRdtEe5RXuoDL25H/media/68e51661bb29150ee473a00f.jpeg" alt="Portrait of Joe Farago" loading="lazy" />
           </div>
-          <div>
-            <h3 class="mentor-name">Joe Farago</h3>
-            <p class="mentor-role">ActionCOACH Practice Owner</p>
-          </div>
-          <p class="mentor-bio">Joe Farago leads a team of certified business and executive coaches as an ActionCOACH practice owner. With decades of experience helping driven business leaders grow profits and performance, Joe combines proven systems, accountability, and no-nonsense strategy to help owners take back control of their time, team, and results.</p>
-          <p class="mentor-bio">As a coach, Joe is known for balancing warmth with rigor—challenging business owners to think bigger, execute smarter, and measure what matters. His practice applies ActionCOACH's globally tested frameworks, refined over 30 years and tens of thousands of businesses, to help entrepreneurs achieve lasting, scalable success.</p>
-          <p class="mentor-bio">Joe's passion lies in seeing business owners not just survive but thrive—building companies that run smoothly, profitably, and sustainably.</p>
+          <div class="host-role">Growth Architecture</div>
+          <div class="host-name">Joe Farago</div>
+          <p>ActionCOACH North Ridgeville. Veteran operator and strategist who helps teams scale without burning through their sanity.</p>
         </article>
       </div>
     </section>
 
-
-    <section id="details" class="container surface" aria-labelledby="details-heading">
-      <div class="section-title">
-        <span class="section-kicker">Know before you go</span>
-        <h2 id="details-heading">Event details</h2>
+    <section class="section" aria-labelledby="value-title">
+      <div class="section-header">
+        <span>The investment</span>
+        <h2 id="value-title">Turn one morning into 2026 momentum.</h2>
       </div>
-      <div class="details-shell">
-        <div class="details-card">
-          <div class="details-grid">
-            <ul>
-              <li><strong>When</strong><span>Wed, Oct 23 • 9:00am–5:30pm (check-in 8:30am)</span></li>
-              <li><strong>Where</strong><span>35590 Center Ridge Rd, #209, North Ridgeville, OH 44039</span></li>
-            </ul>
-            <ul>
-              <li><strong>Includes</strong><span>Light breakfast & lunch</span></li>
-              <li><strong>Seats</strong><span>Only 8 (first come, first served)</span></li>
-              <li><strong>Investment</strong><span>$997 • Payment plans available</span></li>
-            </ul>
-          </div>
-          <div class="details-countdown" aria-live="polite">
-            <strong>Clock is ticking</strong>
-            <span id="details-countdown">Countdown loading…</span>
-            <a class="btn btn-primary cta-highlight" href="#register" data-cta="details-inline">Reserve My Seat</a>
-          </div>
-          <p class="micro-cta">Questions? Email <a href="mailto:support@triumphbusinesssolutions.pro">support@triumphbusinesssolutions.pro</a> or call <a href="tel:14407326647">440-732-6647</a></p>
-        </div>
-      </div>
-      <div class="details-cta">
-        <a class="btn btn-primary cta-highlight" href="#register" data-cta="details">Save My Seat (Only 8 Available)</a>
+      <div class="value-callout">
+        <strong class="price-tag">$397</strong>
+        <p>Includes your seat, workbook materials, and light breakfast. Apply the full amount toward your first six months in The Owner’s Advantage Program when you continue with us.</p>
+        <p style="margin-bottom:0; font-weight:600;">Seats capped at 10 to keep it hands-on.</p>
       </div>
     </section>
 
-    <section class="container surface" aria-labelledby="social-heading">
-      <div class="section-title">
-        <span class="section-kicker">Owners we’ve worked with say…</span>
-        <h2 id="social-heading">Proof you’re in good company</h2>
+    <section id="register" class="register-box" aria-labelledby="register-title">
+      <div>
+        <h2 id="register-title">Ready to reset?</h2>
+        <p>Secure checkout via PayPal. Payment plans available at checkout.</p>
       </div>
-      <div class="testimonial-collage" role="list">
-        <div class="collage-track">
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“I’ve spoken with David several times and every time I walk away with new clarity. He makes financial strategy easy to understand and immediately actionable.”</p>
-            <div class="testimonial-author">
-              <strong>Alex V.</strong>
-              <span>Courtland &amp; Co. Accounting • Real Strategy, Not Fluff</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“Dave is more than a coach—he’s a true partner. His advice helped me unlock a new level of growth I didn’t think was possible.”</p>
-            <div class="testimonial-author">
-              <strong>Sean B.</strong>
-              <span>Cache Consulting • From Stuck to Scaling</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“After one call, David uncovered over $30K in overlooked opportunities. He’s not just looking at numbers—he’s looking at what they mean for your growth.”</p>
-            <div class="testimonial-author">
-              <strong>JJ H.</strong>
-              <span>Victory Leadership Coaching • Results in One Call</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“David doesn’t just give you advice—he makes you feel heard, supported, and confident in your next steps.”</p>
-            <div class="testimonial-author">
-              <strong>Roshni S.</strong>
-              <span>StillFire Healing Inc. • Support You Can Feel</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“David works with profitable and non-profit organizations, is professional, knowledgeable, and has a charismatic personality.”</p>
-            <div class="testimonial-author">
-              <strong>Michelle R.</strong>
-              <span>Coding &amp; Compliance Experts</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“Triumph brings deep experience to find efficiencies and fresh perspective to help you scale. Book time—your conversation will be fruitful.”</p>
-            <div class="testimonial-author">
-              <strong>Doug S.</strong>
-              <span>Fellowship Financial Services</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" aria-hidden="true">
-            <p class="testimonial-quote">“I’ve spoken with David several times and every time I walk away with new clarity. He makes financial strategy easy to understand and immediately actionable.”</p>
-            <div class="testimonial-author">
-              <strong>Alex V.</strong>
-              <span>Courtland &amp; Co. Accounting • Real Strategy, Not Fluff</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" aria-hidden="true">
-            <p class="testimonial-quote">“David doesn’t just give you advice—he makes you feel heard, supported, and confident in your next steps.”</p>
-            <div class="testimonial-author">
-              <strong>Roshni S.</strong>
-              <span>StillFire Healing Inc. • Support You Can Feel</span>
-            </div>
-          </article>
-        </div>
-        <div class="collage-track reverse" aria-hidden="true">
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“If you're looking for someone to bounce ideas off of and help you see your business—and your own potential—in a new light, connect with David. He's fully invested in your success.”</p>
-            <div class="testimonial-author">
-              <strong>Darian T.</strong>
-              <span>Insignia Graphics</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“My first contact with David was eye-opening. He asked about me and my business history. No high-pressure—just a genuine conversation.”</p>
-            <div class="testimonial-author">
-              <strong>Bradd R.</strong>
-              <span>Bradd’s Tax and Bookkeeping</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“David is an incredible insight to have on your team. He looks at your business as if it were his, making sure you succeed.”</p>
-            <div class="testimonial-author">
-              <strong>Charley G.</strong>
-              <span>Chas Enterprise Group</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“I’ve spoken with David several times and every time I walk away energized with a clear next move.”</p>
-            <div class="testimonial-author">
-              <strong>Alex V.</strong>
-              <span>Courtland &amp; Co. Accounting</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" role="listitem">
-            <p class="testimonial-quote">“Dave is more than a coach—he’s a true partner. His advice helped me unlock a new level of growth.”</p>
-            <div class="testimonial-author">
-              <strong>Sean B.</strong>
-              <span>Cache Consulting</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" aria-hidden="true">
-            <p class="testimonial-quote">“My first contact with David was eye-opening. He asked about me and my business history. No high-pressure—just a genuine conversation.”</p>
-            <div class="testimonial-author">
-              <strong>Bradd R.</strong>
-              <span>Bradd’s Tax and Bookkeeping</span>
-            </div>
-          </article>
-          <article class="testimonial-chip" aria-hidden="true">
-            <p class="testimonial-quote">“David is an incredible insight to have on your team. He looks at your business as if it were his, making sure you succeed.”</p>
-            <div class="testimonial-author">
-              <strong>Charley G.</strong>
-              <span>Chas Enterprise Group</span>
-            </div>
-          </article>
-        </div>
+      <div class="paypal-wrap">
+        <div id="paypal-container-XC79A99C7GXLU" role="presentation"></div>
+        <p style="margin-top:0.75rem; font-size:0.9rem;">Having trouble? <a href="https://www.paypal.com/ncp/payment/XC79A99C7GXLU" target="_blank" rel="noopener" style="color:#bfdbfe; font-weight:600;">Open the PayPal checkout in a new tab.</a></p>
       </div>
-    </section>
-
-    <section id="outcomes" class="container surface" aria-labelledby="outcomes-heading">
-      <div class="section-title">
-        <span class="section-kicker">What changes after one day</span>
-        <h2 id="outcomes-heading">In just one day, you’ll gain…</h2>
-      </div>
-      <div class="outcomes-grid">
-        <div>
-          <div class="outcome-accordions">
-            <article class="outcome-item">
-              <button class="outcome-toggle" aria-expanded="false">
-                <span>A clear plan to finally pay yourself first.</span>
-                <svg viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14M5 12h14" /></svg>
-              </button>
-              <div class="outcome-content" hidden>
-                <p>Map your revenue buckets, set owner's pay targets, and lock in a rhythm that funds your priorities before expenses hit.</p>
-              </div>
-            </article>
-            <article class="outcome-item">
-              <button class="outcome-toggle" aria-expanded="false">
-                <span>Clarity on the leaks silently draining profit.</span>
-                <svg viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14M5 12h14" /></svg>
-              </button>
-              <div class="outcome-content" hidden>
-                <p>Trace every dollar leaving your business, flag hidden subscriptions or bloated costs, and build simple guardrails to keep them visible.</p>
-              </div>
-            </article>
-            <article class="outcome-item">
-              <button class="outcome-toggle" aria-expanded="false">
-                <span>A smarter business model designed for sustainable growth.</span>
-                <svg viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14M5 12h14" /></svg>
-              </button>
-              <div class="outcome-content" hidden>
-                <p>Pressure-test your revenue streams, pricing, and delivery so growth scales margins and capacity instead of chaos.</p>
-              </div>
-            </article>
-            <article class="outcome-item">
-              <button class="outcome-toggle" aria-expanded="false">
-                <span>Focus on the few strategies that move the needle next.</span>
-                <svg viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14M5 12h14" /></svg>
-              </button>
-              <div class="outcome-content" hidden>
-                <p>Leave with a ruthless priority map that points your team toward the next three moves that matter—not a 40-item wish list.</p>
-              </div>
-            </article>
-            <article class="outcome-item">
-              <button class="outcome-toggle" aria-expanded="false">
-                <span>A simple action plan you can start this week.</span>
-                <svg viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14M5 12h14" /></svg>
-              </button>
-              <div class="outcome-content" hidden>
-                <p>Translate the day into a 30-60-90 day rollout with milestones, accountability, and momentum baked in.</p>
-              </div>
-            </article>
-          </div>
-          <div class="mini-proof">
-            <span>⏱️ 1 day</span>
-            <span>🧑‍🤝‍🧑 8 owners max</span>
-            <span>✅ hands-on, not theory</span>
-          </div>
-        </div>
-        <div class="hero-visual" aria-hidden="true" style="min-height: 100%;">
-          <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80" alt="Coach leading a small group strategy session" loading="lazy" />
-        </div>
-      </div>
-    </section>
-
-
-    <section id="faqs" class="container surface" aria-labelledby="faq-heading">
-      <div class="section-title">
-        <span class="section-kicker">Questions you might be asking</span>
-        <h2 id="faq-heading">FAQs</h2>
-      </div>
-      <div class="faq">
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>Will this fix everything in a day?</span>
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
-          </button>
-          <div class="faq-answer" hidden>
-            <p>No. You’ll leave with clarity, tools, and a plan you can start immediately.</p>
-          </div>
-        </div>
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>What should I bring?</span>
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
-          </button>
-          <div class="faq-answer" hidden>
-            <p>A notebook or laptop and your key numbers (revenue + major expenses).</p>
-          </div>
-        </div>
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>Payment plans?</span>
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
-          </button>
-          <div class="faq-answer" hidden>
-            <p>Yes—available during checkout. Choose the plan that fits and you’re in.</p>
-          </div>
-        </div>
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>Parking?</span>
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
-          </button>
-          <div class="faq-answer" hidden>
-            <p>On site.</p>
-          </div>
-        </div>
-        <div class="faq-item">
-          <button class="faq-question" aria-expanded="false">
-            <span>Refunds?</span>
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
-          </button>
-          <div class="faq-answer" hidden>
-            <p>Seats are limited; contact us for edge cases.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="register" class="register" aria-labelledby="register-heading">
-      <div class="container">
-        <div class="register-shell">
-          <h2 id="register-heading">Reserve Your Seat</h2>
-          <p class="sub">Only 8 seats — Investment: <strong>$997</strong></p>
-          <p class="micro">Secure checkout • Confirmation email instantly</p>
-          <div class="checkout-frame" role="region" aria-live="polite" aria-label="Secure checkout">
-            <div id="paypal-container-XC79A99C7GXLU"></div>
-            <p class="checkout-help">
-              Having trouble? <a href="https://www.paypal.com/ncp/payment/XC79A99C7GXLU" target="_blank" rel="noopener">Open the secure PayPal checkout</a> in a new tab.
-            </p>
-          </div>
-          <p class="micro" style="margin-bottom: 0;">Ready to move forward? Use the secure checkout above to complete your registration.</p>
-        </div>
-      </div>
+      <p style="font-size:0.95rem;">Questions? Email <a href="mailto:hello@triumphbusinesssolutions.pro" style="color:#bfdbfe; font-weight:600;">hello@triumphbusinesssolutions.pro</a></p>
     </section>
   </main>
 
-  <footer aria-label="Site footer">
-    <div class="footer-inner">
-      <div>
-        <strong>Build the Business You Deserve: Full-Day Intensive</strong>
-        <p>Triumph Business Solutions • 35590 Center Ridge Rd, #209, North Ridgeville, OH 44039</p>
-      </div>
-      <div>
-        <p>Email <a href="mailto:support@triumphbusinesssolutions.pro">support@triumphbusinesssolutions.pro</a> • Call <a href="tel:14407326647">440-732-6647</a></p>
-        <p style="margin-bottom:0;">Secure checkout. Your spot is confirmed via email immediately after payment.</p>
-      </div>
-    </div>
+  <footer>
+    ActionCOACH + Triumph Business Solutions • 35590 Center Ridge Rd #209, North Ridgeville, OH 44039
   </footer>
 
-  <div class="sticky-footer" id="sticky-footer" aria-hidden="false">
-    <p>Oct 23 • Only <span data-seat-pill>8</span> seats • $997</p>
-    <a class="btn btn-primary cta-highlight" href="#register" data-cta="sticky">Register Now</a>
-  </div>
-
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    window.addEventListener('load', function () {
       if (window.paypal?.HostedButtons) {
-        paypal
-          .HostedButtons({ hostedButtonId: 'XC79A99C7GXLU' })
-          .render('#paypal-container-XC79A99C7GXLU');
+        window.paypal.HostedButtons({
+          hostedButtonId: 'XC79A99C7GXLU'
+        }).render('#paypal-container-XC79A99C7GXLU');
       }
-    });
-  </script>
-
-  <script>
-    const EVENT_START = new Date('2025-10-23T09:00:00-04:00');
-    const WAITLIST_MAILTO = 'mailto:support@triumphbusinesssolutions.pro?subject=Join%20the%20Waitlist&body=Please%20let%20me%20know%20if%20a%20seat%20opens.';
-    const SEATS_LEFT = 8; // Update manually as seats are sold
-
-    const daysEl = document.getElementById('days');
-    const hoursEl = document.getElementById('hours');
-    const minutesEl = document.getElementById('minutes');
-    const secondsEl = document.getElementById('seconds');
-    const countdownMessage = document.getElementById('countdown-message');
-    const countdownNote = document.getElementById('countdown-note');
-    const detailsCountdown = document.getElementById('details-countdown');
-    const heroPrimary = document.querySelector('[data-cta="hero-primary"]');
-    const stickyCTA = document.querySelector('[data-cta="sticky"]');
-    const seatPills = document.querySelectorAll('[data-seat-pill]');
-    const painCards = document.querySelectorAll('.pain-card');
-
-    function updateSeatsLeft(count) {
-      seatPills.forEach(el => (el.textContent = count));
-    }
-
-    function formatNumber(num) {
-      return String(num).padStart(2, '0');
-    }
-
-    function handleCountdown() {
-      const now = new Date();
-      const diff = EVENT_START - now;
-
-      if (diff <= 0) {
-        daysEl.textContent = '00';
-        hoursEl.textContent = '00';
-        minutesEl.textContent = '00';
-        secondsEl.textContent = '00';
-        countdownMessage.innerHTML = 'Registration may be closed—<a href="' + WAITLIST_MAILTO + '">join the waitlist</a>.';
-        countdownNote.textContent = 'Spots go fast. Reach out to see if a seat opens.';
-        detailsCountdown.textContent = 'Event in progress or completed.';
-        if (heroPrimary) {
-          heroPrimary.textContent = 'Join Waitlist';
-          heroPrimary.setAttribute('href', WAITLIST_MAILTO);
-        }
-        if (stickyCTA) {
-          stickyCTA.textContent = 'Join Waitlist';
-          stickyCTA.setAttribute('href', WAITLIST_MAILTO);
-        }
-        return;
-      }
-
-      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-      const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-      const minutes = Math.floor((diff / (1000 * 60)) % 60);
-      const seconds = Math.floor((diff / 1000) % 60);
-
-      daysEl.textContent = formatNumber(days);
-      hoursEl.textContent = formatNumber(hours);
-      minutesEl.textContent = formatNumber(minutes);
-      secondsEl.textContent = formatNumber(seconds);
-      countdownMessage.textContent = `Oct 23 • Only ${SEATS_LEFT} seats • $997`;
-      detailsCountdown.textContent = `${days} days • ${hours} hours until we start`;
-      requestAnimationFrame(() => {
-        setTimeout(handleCountdown, 1000);
-      });
-    }
-
-    function resetOtherPainCards(activeCard) {
-      painCards.forEach(card => {
-        if (card !== activeCard) {
-          card.setAttribute('aria-expanded', 'false');
-          card.classList.remove('open');
-          const answer = card.querySelector('.pain-card-answer');
-          if (answer) {
-            answer.style.maxHeight = '0px';
-          }
-        }
-      });
-    }
-
-    painCards.forEach(card => {
-      const answer = card.querySelector('.pain-card-answer');
-      if (answer) {
-        answer.style.maxHeight = '0px';
-      }
-
-      card.addEventListener('click', () => {
-        const expanded = card.getAttribute('aria-expanded') === 'true';
-        resetOtherPainCards(card);
-        card.setAttribute('aria-expanded', String(!expanded));
-        card.classList.toggle('open', !expanded);
-
-        if (answer) {
-          if (!expanded) {
-            answer.style.maxHeight = answer.scrollHeight + 'px';
-          } else {
-            answer.style.maxHeight = '0px';
-          }
-        }
-      });
-    });
-
-    updateSeatsLeft(SEATS_LEFT);
-    handleCountdown();
-
-    const stickyFooter = document.getElementById('sticky-footer');
-    const registerSection = document.getElementById('register');
-    if ('IntersectionObserver' in window && stickyFooter && registerSection) {
-      const observer = new IntersectionObserver(entries => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            stickyFooter.setAttribute('aria-hidden', 'true');
-            stickyFooter.style.transform = 'translateY(100%)';
-          } else {
-            stickyFooter.setAttribute('aria-hidden', 'false');
-            stickyFooter.style.transform = 'translateY(0)';
-          }
-        });
-      }, { threshold: 0.25 });
-      observer.observe(registerSection);
-    }
-
-    const outcomeToggles = document.querySelectorAll('.outcome-toggle');
-    outcomeToggles.forEach(toggle => {
-      const item = toggle.closest('.outcome-item');
-      const content = item?.querySelector('.outcome-content');
-      if (!content) return;
-
-      content.style.maxHeight = '0px';
-
-      toggle.addEventListener('click', () => {
-        const expanded = toggle.getAttribute('aria-expanded') === 'true';
-        toggle.setAttribute('aria-expanded', String(!expanded));
-        item.classList.toggle('open', !expanded);
-
-        if (!expanded) {
-          content.hidden = false;
-          const height = content.scrollHeight;
-          content.style.maxHeight = height + 'px';
-        } else {
-          const height = content.scrollHeight;
-          content.style.maxHeight = height + 'px';
-          requestAnimationFrame(() => {
-            content.style.maxHeight = '0px';
-          });
-          content.addEventListener('transitionend', function handle(e) {
-            if (e.propertyName === 'max-height') {
-              content.hidden = true;
-              content.removeEventListener('transitionend', handle);
-            }
-          });
-        }
-      });
-    });
-
-    const faqButtons = document.querySelectorAll('.faq-question');
-    faqButtons.forEach(button => {
-      const item = button.closest('.faq-item');
-      const answer = item?.querySelector('.faq-answer');
-      if (!answer) return;
-
-      answer.style.maxHeight = '0px';
-
-      button.addEventListener('click', () => {
-        const expanded = button.getAttribute('aria-expanded') === 'true';
-        button.setAttribute('aria-expanded', String(!expanded));
-        item.classList.toggle('open', !expanded);
-
-        if (!expanded) {
-          answer.hidden = false;
-          const height = answer.scrollHeight;
-          answer.style.maxHeight = height + 'px';
-        } else {
-          const height = answer.scrollHeight;
-          answer.style.maxHeight = height + 'px';
-          requestAnimationFrame(() => {
-            answer.style.maxHeight = '0px';
-          });
-          answer.addEventListener('transitionend', function handle(e) {
-            if (e.propertyName === 'max-height') {
-              answer.hidden = true;
-              answer.removeEventListener('transitionend', handle);
-            }
-          });
-        }
-      });
     });
   </script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Event",
-      "name": "Build the Business You Deserve: Full-Day Intensive",
-      "startDate": "2025-10-23T09:00:00-04:00",
-      "endDate": "2025-10-23T17:30:00-04:00",
+      "name": "2026 Business Reset Workshop",
+      "startDate": "2025-11-19T09:00:00-05:00",
+      "endDate": "2025-11-19T12:30:00-05:00",
       "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
       "eventStatus": "https://schema.org/EventScheduled",
       "location": {
         "@type": "Place",
-        "name": "Triumph x ActionCOACH Session",
+        "name": "ActionCOACH + Triumph Business Solutions",
         "address": {
           "@type": "PostalAddress",
           "streetAddress": "35590 Center Ridge Rd, #209",
@@ -1680,16 +495,16 @@
           "addressCountry": "US"
         }
       },
+      "description": "Half-day Profit First intensive for owners ready to enter 2026 with clarity, cash control, and a 90-day plan.",
       "image": ["https://example.com/og-image.jpg"],
-      "description": "One-day, small-group intensive for business owners. Gain clarity, stop profit leaks, and leave with an action plan.",
       "offers": {
         "@type": "Offer",
-        "price": "997.00",
+        "price": "397.00",
         "priceCurrency": "USD",
         "availability": "https://schema.org/LimitedAvailability",
         "url": "https://example.com/register"
       },
-      "maximumAttendeeCapacity": 8,
+      "maximumAttendeeCapacity": 10,
       "organizer": {
         "@type": "Organization",
         "name": "Triumph Business Solutions",
@@ -1697,6 +512,5 @@
       }
     }
   </script>
-  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the hero copy and details to reflect the 8:30 check-in and 9:00–12:30 program window
- replace the agenda timeline with the detailed sessions and wrap-up provided for the half-day format
- restore Joe and Dave headshots with circular styling while keeping the $397 value callout intact

## Testing
- python -m http.server 8000 (for manual visual verification)


------
https://chatgpt.com/codex/tasks/task_e_6903780f0460832c907a424220066827